### PR TITLE
refactor: model all services as ApiService

### DIFF
--- a/google-cloud-spanner-change-publisher/src/main/java/com/google/cloud/spanner/publisher/SpannerToAvro.java
+++ b/google-cloud-spanner-change-publisher/src/main/java/com/google/cloud/spanner/publisher/SpannerToAvro.java
@@ -30,6 +30,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.Futures;
 import com.google.protobuf.ByteString;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -84,7 +85,7 @@ class SpannerToAvro {
   }
 
   private SchemaSet createSchemaSet() {
-    String tsColName = SpannerUtils.getTimestampColumn(client, table);
+    String tsColName = Futures.getUnchecked(SpannerUtils.getTimestampColumn(client, table));
     try (ResultSet resultSet = client.singleUse().executeQuery(statement)) {
       return convertTableToSchemaSet(table, "avroNamespace", resultSet, tsColName);
     }

--- a/google-cloud-spanner-change-publisher/src/test/java/com/google/cloud/spanner/publisher/SpannerToAvroTest.java
+++ b/google-cloud-spanner-change-publisher/src/test/java/com/google/cloud/spanner/publisher/SpannerToAvroTest.java
@@ -540,7 +540,7 @@ public class SpannerToAvroTest {
     DatabaseClient client = mock(DatabaseClient.class);
     ReadContext context = mock(ReadContext.class);
     when(client.singleUse()).thenReturn(context);
-    when(context.executeQuery(
+    when(context.executeQueryAsync(
             Statement.newBuilder(SpannerUtils.FIND_COMMIT_TIMESTAMP_COLUMN_QUERY)
                 .bind("catalog")
                 .to("")
@@ -549,7 +549,7 @@ public class SpannerToAvroTest {
                 .bind("table")
                 .to("FOO")
                 .build()))
-        .thenReturn(createTimestampColumnResultSet());
+        .thenReturn(ResultSets.toAsyncResultSet(createTimestampColumnResultSet()));
     when(context.executeQuery(
             Statement.newBuilder(SpannerToAvro.SCHEMA_QUERY)
                 .bind("catalog")

--- a/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerDatabaseChangeWatcher.java
+++ b/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerDatabaseChangeWatcher.java
@@ -16,21 +16,20 @@
 
 package com.google.cloud.spanner.watcher;
 
-import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiService;
+import com.google.api.core.ApiService.State;
 import com.google.cloud.spanner.watcher.SpannerTableChangeWatcher.RowChangeCallback;
 import java.util.Collection;
 
 /** Interface for capturing changes to a set of tables in a Spanner database. */
-public interface SpannerDatabaseChangeWatcher {
+public interface SpannerDatabaseChangeWatcher extends ApiService {
   /** Returns the ids of the tables that are monitored by this watcher. */
   Collection<TableId> getTables();
 
-  /** Returns the watcher for the given table. */
-  SpannerTableChangeWatcher getCapturer(TableId table);
-
-  /** Run this watcher and report all changed rows to the given {@link RowChangeCallback}. */
-  void start(RowChangeCallback callback);
-
-  /** Stop this watcher. */
-  ApiFuture<Void> stopAsync();
+  /**
+   * Adds a {@link RowChangeCallback} for this {@link SpannerDatabaseChangeWatcher}. Callbacks may
+   * only be added when the {@link #state()} of this {@link SpannerDatabaseChangeWatcher} is {@link
+   * State#NEW}
+   */
+  void addCallback(RowChangeCallback callback);
 }

--- a/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerTableChangeWatcher.java
+++ b/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerTableChangeWatcher.java
@@ -16,13 +16,13 @@
 
 package com.google.cloud.spanner.watcher;
 
-import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiService;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.StructReader;
 
 /** Interface for capturing changes to a single Spanner table. */
-public interface SpannerTableChangeWatcher {
+public interface SpannerTableChangeWatcher extends ApiService {
 
   /** Returns the id of the table that is monitored by this watcher. */
   TableId getTable();
@@ -46,9 +46,10 @@ public interface SpannerTableChangeWatcher {
     void rowChange(TableId table, Row row, Timestamp commitTimestamp);
   }
 
-  /** Run this watcher and report all changed rows to the given {@link RowChangeCallback}. */
-  void start(RowChangeCallback callback);
-
-  /** Stop this change watcher. */
-  ApiFuture<Void> stopAsync();
+  /**
+   * Adds a {@link RowChangeCallback} for this {@link SpannerTableChangeWatcher}. Callbacks may only
+   * be added when the {@link #state()} of this {@link SpannerTableChangeWatcher} is {@link
+   * State#NEW}
+   */
+  void addCallback(RowChangeCallback callback);
 }

--- a/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/TableId.java
+++ b/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/TableId.java
@@ -19,6 +19,7 @@ package com.google.cloud.spanner.watcher;
 import com.google.api.client.util.Preconditions;
 import com.google.cloud.spanner.DatabaseId;
 import com.google.common.base.Strings;
+import java.util.Objects;
 
 public class TableId {
   public static class Builder {
@@ -106,5 +107,22 @@ public class TableId {
   @Override
   public String toString() {
     return fullName;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(databaseId, catalog, schema, table);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof TableId)) {
+      return false;
+    }
+    TableId other = (TableId) o;
+    return Objects.equals(databaseId, other.databaseId)
+        && Objects.equals(catalog, other.catalog)
+        && Objects.equals(schema, other.schema)
+        && Objects.equals(table, other.table);
   }
 }

--- a/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/it/ITSpannerDatabaseTailerTest.java
+++ b/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/it/ITSpannerDatabaseTailerTest.java
@@ -85,7 +85,7 @@ public class ITSpannerDatabaseTailerTest {
                     .setInitialCommitTimestamp(Timestamp.MIN_VALUE)
                     .build())
             .build();
-    tailer.start(
+    tailer.addCallback(
         new RowChangeCallback() {
           @Override
           public void rowChange(TableId table, Row row, Timestamp commitTimestamp) {
@@ -96,6 +96,7 @@ public class ITSpannerDatabaseTailerTest {
             latch.countDown();
           }
         });
+    tailer.startAsync().awaitRunning();
 
     DatabaseClient client = spanner.getDatabaseClient(database.getId());
     latch = new CountDownLatch(3);
@@ -247,7 +248,7 @@ public class ITSpannerDatabaseTailerTest {
                 Mutation.delete("NUMBERS2", Key.of(2L)), Mutation.delete("NUMBERS1", Key.of(3L))));
     Thread.sleep(500L);
     assertThat(receivedChanges).isEmpty();
-    tailer.stopAsync().get();
+    tailer.stopAsync().awaitTerminated();
   }
 
   private ImmutableList<Struct> drainChanges() throws Exception {

--- a/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/it/ITSpannerTableTailerTest.java
+++ b/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/it/ITSpannerTableTailerTest.java
@@ -83,7 +83,7 @@ public class ITSpannerTableTailerTest {
                     .setCreateTableIfNotExists()
                     .build())
             .build();
-    tailer.start(
+    tailer.addCallback(
         new RowChangeCallback() {
           @Override
           public void rowChange(TableId table, Row row, Timestamp commitTimestamp) {
@@ -94,6 +94,7 @@ public class ITSpannerTableTailerTest {
             latch.countDown();
           }
         });
+    tailer.startAsync().awaitRunning();
 
     DatabaseClient client = spanner.getDatabaseClient(database.getId());
     latch = new CountDownLatch(3);
@@ -245,7 +246,7 @@ public class ITSpannerTableTailerTest {
                 Mutation.delete("NUMBERS", Key.of(2L)), Mutation.delete("NUMBERS", Key.of(3L))));
     Thread.sleep(500L);
     assertThat(receivedChanges).isEmpty();
-    tailer.stopAsync().get();
+    tailer.stopAsync().awaitTerminated();
   }
 
   private ImmutableList<Struct> drainChanges() throws Exception {


### PR DESCRIPTION
Using ApiService as a common interface for change watchers and publishers ensures that users have a consistent interface for starting, stopping and managing the services offered by the library. These also automatically include error handling and asynchronous start and stop.

Fixes #1
