### PR TITLE
docs: add javadoc to public classes and methods

### DIFF
--- a/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/Samples.java
+++ b/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/Samples.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import org.threeten.bp.Duration;
 
+/** Samples for spanner-change-watcher. */
 class Samples {
 
   /** Watch a single table in a database for changes. */

--- a/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerCommitTimestampRepository.java
+++ b/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerCommitTimestampRepository.java
@@ -40,7 +40,7 @@ import javax.annotation.Nullable;
  * {@link CommitTimestampRepository} that stores the last seen commit timestamp for a table in a
  * Cloud Spanner database table. The default table definition to use is
  *
- * <pre>
+ * <pre>{@code
  * CREATE TABLE LAST_SEEN_COMMIT_TIMESTAMPS (
  *        DATABASE_NAME STRING(MAX) NOT NULL,
  *        TABLE_CATALOG STRING(MAX) NOT NULL,
@@ -48,7 +48,7 @@ import javax.annotation.Nullable;
  *        TABLE_NAME STRING(MAX) NOT NULL,
  *        LAST_SEEN_COMMIT_TIMESTAMP TIMESTAMP NOT NULL
  * ) PRIMARY KEY (DATABASE_NAME, TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME)
- * </pre>
+ * }</pre>
  *
  * The table name and column names are configurable.
  */

--- a/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerUtils.java
+++ b/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerUtils.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner.watcher;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.InternalApi;
 import com.google.api.core.SettableApiFuture;
 import com.google.cloud.spanner.AsyncResultSet;
 import com.google.cloud.spanner.AsyncResultSet.CallbackResponse;
@@ -34,6 +35,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.MoreExecutors;
 
 /** Utils for getting commonly needed schema information from a Spanner database. */
+@InternalApi(
+    "Public visibility for re-use by other spanner-change-watcher libraries. API-breaking changes without prior notice is possible.")
 public class SpannerUtils {
   /** Query for getting the column of a table that holds the commit timestamp. */
   @VisibleForTesting
@@ -55,6 +58,7 @@ public class SpannerUtils {
           + "ORDER BY INDEX_COLUMNS.ORDINAL_POSITION";
 
   /** Returns the name of the commit timestamp column of the given table. */
+  @InternalApi
   public static ApiFuture<String> getTimestampColumn(DatabaseClient client, TableId table) {
     final SettableApiFuture<String> res = SettableApiFuture.create();
     try (AsyncResultSet rs =
@@ -104,6 +108,8 @@ public class SpannerUtils {
     return res;
   }
 
+  /** Returns the primary key columns of a table. */
+  @InternalApi
   public static ApiFuture<ImmutableList<String>> getPrimaryKeyColumns(
       DatabaseClient client, TableId table) {
     try (AsyncResultSet rs =
@@ -129,6 +135,11 @@ public class SpannerUtils {
     }
   }
 
+  /**
+   * Creates a {@link Key} instance from an {@link Iterable} of primary key columns and a {@link
+   * ResultSet} containing the data to use for the key.
+   */
+  @InternalApi
   public static Key buildKey(Iterable<String> pkColumns, ResultSet rs) {
     Key.Builder kb = Key.newBuilder();
     for (String pkCol : pkColumns) {

--- a/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/TableId.java
+++ b/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/TableId.java
@@ -21,8 +21,9 @@ import com.google.cloud.spanner.DatabaseId;
 import com.google.common.base.Strings;
 import java.util.Objects;
 
-public class TableId {
-  public static class Builder {
+/** Unique id of a Cloud Spanner table. */
+public final class TableId {
+  static class Builder {
     private final DatabaseId databaseId;
     private final String table;
     private String catalog = "";
@@ -33,25 +34,26 @@ public class TableId {
       this.table = Preconditions.checkNotNull(table);
     }
 
-    public Builder setCatalog(String catalog) {
+    Builder setCatalog(String catalog) {
       this.catalog = Preconditions.checkNotNull(catalog);
       return this;
     }
 
-    public Builder setSchema(String schema) {
+    Builder setSchema(String schema) {
       this.schema = Preconditions.checkNotNull(schema);
       return this;
     }
 
-    public TableId build() {
+    TableId build() {
       return new TableId(this);
     }
   }
 
-  public static Builder newBuilder(DatabaseId databaseId, String table) {
+  static Builder newBuilder(DatabaseId databaseId, String table) {
     return new Builder(databaseId, table);
   }
 
+  /** Creates a {@link TableId} for the given table in the given database. */
   public static TableId of(DatabaseId databaseId, String table) {
     return newBuilder(databaseId, table).build();
   }


### PR DESCRIPTION
* Adds javadoc to public classes and methods.
* Reduces visibility of classes and methods where possible.
* Marks internal public classes as `@InternalApi`