### PR TITLE
feat: create topics if not exist

### DIFF
--- a/google-cloud-spanner-change-publisher/src/main/java/com/google/cloud/spanner/publisher/Configuration.java
+++ b/google-cloud-spanner-change-publisher/src/main/java/com/google/cloud/spanner/publisher/Configuration.java
@@ -46,8 +46,9 @@ class Configuration {
 
   // Publisher settings.
   private String pubsubProject;
-  private String topicNameFormat;
   private Credentials pubsubCredentials;
+  private String topicNameFormat;
+  private boolean createTopics;
 
   Long getMaxWaitForShutdownSeconds() {
     return maxWaitForShutdownSeconds;
@@ -86,6 +87,10 @@ class Configuration {
 
   String getTopicNameFormat() {
     return topicNameFormat;
+  }
+
+  boolean createTopics() {
+    return createTopics;
   }
 
   String getPubsubProject() {
@@ -196,6 +201,10 @@ class Configuration {
       throw new IllegalArgumentException(
           "Invalid configuration: pubsub.topicNameFormat is required.");
     }
+    config.createTopics =
+        Boolean.valueOf(
+            MoreObjects.firstNonNull(
+                getSystemOrDefaultProperty("pubsub.createTopics", defaults), "false"));
 
     return config;
   }

--- a/google-cloud-spanner-change-publisher/src/main/java/com/google/cloud/spanner/publisher/Samples.java
+++ b/google-cloud-spanner-change-publisher/src/main/java/com/google/cloud/spanner/publisher/Samples.java
@@ -178,7 +178,10 @@ public class Samples {
     eventPublisher.stopAsync().awaitTerminated();
   }
 
-  /** Publish changes from all tables in a database to a separate Pubsub topic per table. */
+  /**
+   * Publish changes from all tables in a database to a separate Pubsub topic per table. The topics
+   * are created automatically by the Publisher.
+   */
   public void publishChangesFromAllTablesToSeparateTopicsExample(
       String instance, // "my-instance"
       String database // "my-database"
@@ -204,6 +207,7 @@ public class Samples {
         SpannerDatabaseChangeEventPublisher.newBuilder(watcher, client)
             .setTopicNameFormat(
                 String.format("projects/%s/topics/%s", pubsubProjectId, topicFormat))
+            .setCreateTopicsIfNotExist(true)
             .addListener(
                 new PublishListener() {
                   @Override

--- a/google-cloud-spanner-change-publisher/src/test/java/com/google/cloud/spanner/publisher/it/ITSamplesTest.java
+++ b/google-cloud-spanner-change-publisher/src/test/java/com/google/cloud/spanner/publisher/it/ITSamplesTest.java
@@ -342,17 +342,13 @@ public class ITSamplesTest {
 
   @Test
   public void testPublishChangesFromAllTablesToSeparateTopicsExample() throws Exception {
-    // First create the topics that the publishers will use and the corresponding subscriptions that
-    // can be used to listen for the changes.
+    // The topics will automatically be created by the publisher, but this ensures they are deleted
+    // after the test has run.
     // topicFormat = "change-log-%database%-%table%";
     String topic1 = String.format("change-log-%s-NUMBERS1", databaseId.getDatabase());
     String topic2 = String.format("change-log-%s-NUMBERS2", databaseId.getDatabase());
-    String subscription1 = String.format("sub-change-log-%s-NUMBERS1", databaseId.getDatabase());
-    String subscription2 = String.format("sub-change-log-%s-NUMBERS2", databaseId.getDatabase());
-    env.createTestTopic(topic1);
-    env.createTestTopic(topic2);
-    env.createTestSubscription(topic1, subscription1);
-    env.createTestSubscription(topic2, subscription2);
+    env.registerTestTopic(topic1);
+    env.registerTestTopic(topic2);
 
     CountDownLatch latch = new CountDownLatch(1);
     Samples samples =
@@ -369,6 +365,12 @@ public class ITSamplesTest {
             },
             latch);
     assertThat(latch.await(60L, TimeUnit.SECONDS)).isTrue();
+
+    String subscription1 = String.format("sub-change-log-%s-NUMBERS1", databaseId.getDatabase());
+    String subscription2 = String.format("sub-change-log-%s-NUMBERS2", databaseId.getDatabase());
+    // Create a couple of subscriptions to get the published changes.
+    env.createTestSubscription(topic1, subscription1);
+    env.createTestSubscription(topic2, subscription2);
 
     final CountDownLatch receivedMessagesLatch = new CountDownLatch(3);
     final List<ByteString> receivedRows1 = new ArrayList<>(3);

--- a/google-cloud-spanner-change-publisher/src/test/java/com/google/cloud/spanner/publisher/it/PubsubTestHelper.java
+++ b/google-cloud-spanner-change-publisher/src/test/java/com/google/cloud/spanner/publisher/it/PubsubTestHelper.java
@@ -76,6 +76,10 @@ public final class PubsubTestHelper {
       logger.info(String.format("Created topic %s", topic));
     }
 
+    public void registerTestTopic(String topic) {
+      topics.add(topic);
+    }
+
     public void createTestSubscription(String topic, String subscription) {
       subAdminClient.createSubscription(
           String.format(


### PR DESCRIPTION
`google-cloud-change-publisher` can now automatically create the Pubsub topic(s) that are needed.

Fixes #20