### PR TITLE
chore: run CI nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # Orb 'circleci/maven@0.0.12' resolved to 'circleci/maven@0.0.12'
 version: 2
 jobs:
-  maven/test:
+  build_and_test:
     docker:
     - image: circleci/openjdk:8-jdk-node
     steps:
@@ -45,7 +45,19 @@ jobs:
     - store_test_results:
         path: target/surefire-reports
 workflows:
-  maven_test:
-    jobs:
-    - maven/test
   version: 2
+  
+  commit:  # Run on every commit.
+    jobs:
+      - build_and_test
+
+  nightly:  # Run every night.
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                  - master
+    jobs:
+      - build_and_test

--- a/google-cloud-spanner-change-publisher/pom.xml
+++ b/google-cloud-spanner-change-publisher/pom.xml
@@ -22,11 +22,21 @@
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpclient</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-protobuf-lite</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <junit.version>4.13</junit.version>
     <truth.version>1.0.1</truth.version>
     <mockito.version>3.3.3</mockito.version>
-    <spanner.test.version>1.53.0</spanner.test.version>
+    <spanner.test.version>1.56.0</spanner.test.version>
   </properties>
   
   <dependencyManagement>
@@ -52,11 +52,20 @@
       
       <dependency>
         <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-spanner-bom</artifactId>
+        <type>pom</type>
+        <scope>import</scope>
+        <version>1.56.0</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>5.3.0</version>
+        <version>7.0.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- TODO: Remove this once the test-jar is included in the bom -->
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-spanner</artifactId>


### PR DESCRIPTION
Run CI jobs every night to prevent changes in the Spanner client that might break spanner-change-watcher from going unnoticed.