### PR TITLE
docs: add information on ordering of callbacks

### DIFF
--- a/google-cloud-spanner-change-publisher/src/main/java/com/google/cloud/spanner/publisher/SpannerDatabaseChangeEventPublisher.java
+++ b/google-cloud-spanner-change-publisher/src/main/java/com/google/cloud/spanner/publisher/SpannerDatabaseChangeEventPublisher.java
@@ -59,6 +59,11 @@ import java.util.logging.Logger;
  * then sent to Pubsub by this event publisher. The publisher can be configured to publish change
  * events from each table to a separate topic, or to publish all changes to a single topic. Each
  * change event contains the {@link TableId}, the new row data and the commit timestamp.
+ *
+ * <p>Changes to one table are guaranteed to be published in order of commit timestamp, but Pubsub
+ * does not guarantee that messages will be delivered in the same order as they were published. See
+ * https://cloud.google.com/pubsub/docs/ordering for more information. There is also no guarantee in
+ * the order which changes to different tables are published to Pubsub.
  */
 public class SpannerDatabaseChangeEventPublisher extends AbstractApiService implements ApiService {
   private static final Logger logger =

--- a/google-cloud-spanner-change-publisher/src/main/java/com/google/cloud/spanner/publisher/SpannerTableChangeEventPublisher.java
+++ b/google-cloud-spanner-change-publisher/src/main/java/com/google/cloud/spanner/publisher/SpannerTableChangeEventPublisher.java
@@ -56,7 +56,9 @@ import java.util.logging.Logger;
  * Publishes change events from a single Spanner table to a single Google Cloud Pubsub topic.
  *
  * <p>The changes to the table are emitted from a {@link SpannerTableChangeWatcher} and then sent to
- * Google Cloud Pubsub by this event publisher.
+ * Google Cloud Pubsub by this event publisher. Changes are guaranteed to be published in order of
+ * commit timestamp, but Pubsub does not guarantee that messages will be delivered in the same order
+ * as they were published. See https://cloud.google.com/pubsub/docs/ordering for more information.
  */
 public class SpannerTableChangeEventPublisher extends AbstractApiService implements ApiService {
   private static final Logger logger =

--- a/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerDatabaseChangeWatcher.java
+++ b/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerDatabaseChangeWatcher.java
@@ -37,7 +37,9 @@ public interface SpannerDatabaseChangeWatcher extends ApiService {
   /**
    * Adds a {@link RowChangeCallback} for this {@link SpannerDatabaseChangeWatcher}. Callbacks may
    * only be added when the {@link #state()} of this {@link SpannerDatabaseChangeWatcher} is {@link
-   * State#NEW}
+   * State#NEW}. Callbacks for one table will always be in order of commit timestamp, and only one
+   * callback will be active at any time for a table. Callbacks for different tables may be called
+   * in parallel, and there is no guarantee to the ordering of callbacks over multiple tables.
    */
   void addCallback(RowChangeCallback callback);
 }

--- a/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerTableChangeWatcher.java
+++ b/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerTableChangeWatcher.java
@@ -37,7 +37,7 @@ public interface SpannerTableChangeWatcher extends ApiService {
   interface RowChangeCallback {
     /**
      * Called once for each detected insert or update of a row. Calls are guaranteed to be in order
-     * of detected changes.
+     * of commit timestamp of the changes.
      *
      * @param table The table where the data was inserted or updated.
      * @param row The updated data of the row that was inserted or updated.
@@ -54,9 +54,9 @@ public interface SpannerTableChangeWatcher extends ApiService {
    * heavy computations or blocking operations to a non-blocking executor or buffer.
    *
    * <p>The {@link SpannerTableChangeWatcher} guarantees that at most one {@link RowChangeCallback}
-   * will be active at any given time, and all callbacks will receive all changes in order. There is
-   * no guarantee in the order which callback is called first if a {@link SpannerTableChangeWatcher}
-   * has registered multiple callbacks.
+   * will be active at any given time, and all callbacks will receive all changes in order of commit
+   * timestamp. There is no guarantee as to the order of which callback is called first if a {@link
+   * SpannerTableChangeWatcher} has registered multiple callbacks.
    */
   void addCallback(RowChangeCallback callback);
 }


### PR DESCRIPTION
Adds information on the ordering of callbacks and publish messages.