### PR TITLE
test: first inc row count then latch count down

### DIFF
--- a/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/SpannerDatabaseTailerTest.java
+++ b/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/SpannerDatabaseTailerTest.java
@@ -64,8 +64,8 @@ public class SpannerDatabaseTailerTest extends AbstractMockServerTest {
         new RowChangeCallback() {
           @Override
           public void rowChange(TableId table, Row row, Timestamp commitTimestamp) {
-            latch.countDown();
             receivedRows.incrementAndGet();
+            latch.countDown();
           }
         });
     tailer.startAsync().awaitRunning();
@@ -119,8 +119,8 @@ public class SpannerDatabaseTailerTest extends AbstractMockServerTest {
         new RowChangeCallback() {
           @Override
           public void rowChange(TableId table, Row row, Timestamp commitTimestamp) {
-            latch.countDown();
             receivedRows.incrementAndGet();
+            latch.countDown();
           }
         });
     SettableApiFuture<Boolean> res = SettableApiFuture.create();
@@ -176,8 +176,8 @@ public class SpannerDatabaseTailerTest extends AbstractMockServerTest {
         new RowChangeCallback() {
           @Override
           public void rowChange(TableId table, Row row, Timestamp commitTimestamp) {
-            latch.countDown();
             receivedRows.incrementAndGet();
+            latch.countDown();
           }
         });
     tailer.startAsync().awaitRunning();


### PR DESCRIPTION
Fixes race conditions in the test where the `latch.countDown()` was executed before increasing the row count, causing flaky failures.