### PR TITLE
build: execute integration tests in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 # Orb 'circleci/maven@0.0.12' resolved to 'circleci/maven@0.0.12'
-version: 2
+version: 2.1
 jobs:
   build_and_test:
     parameters:
@@ -45,7 +45,7 @@ jobs:
     - store_test_results:
         path: target/surefire-reports
 workflows:
-  version: 2
+  version: 2.1
   
   commit:  # Run on every commit.
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,10 @@
 version: 2
 jobs:
   build_and_test:
+    parameters:
+      run-stress-tests:
+        type: boolean
+        default: false
     docker:
     - image: circleci/openjdk:8-jdk-node
     steps:
@@ -11,19 +15,6 @@ jobs:
         command: find . -name 'pom.xml' | sort | xargs cat > /tmp/maven_cache_seed
     - restore_cache:
         key: maven-{{ checksum "/tmp/maven_cache_seed" }}
-    - attach_workspace:
-        at: ~/java-spanner
-    - run:
-        name: Clone and install java-spanner repository
-        command: |
-          echo Cloning java-spanner
-          git clone git@github.com:googleapis/java-spanner.git ~/java-spanner
-          echo Switching to java-spanner workspace
-          cd ~/java-spanner
-          echo Checking out Async API
-          git checkout master
-          echo Installing snapshot version of java-spanner
-          mvn -DskipTests clean install
     - run:
         name: Install Dependencies
         command: mvn -DskipTests clean install dependency:resolve-plugins dependency:go-offline --settings 'pom.xml'
@@ -35,9 +26,18 @@ jobs:
         command: |
           echo $GCLOUD_SERVICE_KEY > $HOME/gcloud-service-key.json
           echo 'export GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcloud-service-key.json' >> $BASH_ENV
-    - run:
-        name: Run Integration Tests
-        command: mvn -B -Penable-integration-tests -DtrimStackTrace=false -fae verify --settings 'pom.xml'
+    - when:
+        condition: << parameters.run-stress-tests >>
+        steps:
+          - run: 
+              name: Run Integration and Stress Tests
+              command: mvn -B -Penable-integration-tests -Pstress-integration-tests -DtrimStackTrace=false -fae verify --settings 'pom.xml'
+    - unless:
+        condition: << parameters.run-stress-tests >>
+        steps:
+            - run:
+                name: Run Integration Tests
+                command: mvn -B -Penable-integration-tests -DtrimStackTrace=false -fae verify --settings 'pom.xml'
     - save_cache:
         paths:
         - ~/.m2
@@ -60,4 +60,5 @@ workflows:
               only:
                   - master
     jobs:
-      - build_and_test
+      - build_and_test:
+          run-stress-tests: true

--- a/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/it/ITSpannerDatabaseTailerStressTest.java
+++ b/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/it/ITSpannerDatabaseTailerStressTest.java
@@ -64,12 +64,14 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.threeten.bp.Duration;
 
+@Category(StressIntegrationTest.class)
 @RunWith(Parameterized.class)
 public class ITSpannerDatabaseTailerStressTest {
   private static final String[] TABLE_NAMES =

--- a/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/it/ITSpannerTableTailerStressTest.java
+++ b/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/it/ITSpannerTableTailerStressTest.java
@@ -66,12 +66,14 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.threeten.bp.Duration;
 
+@Category(StressIntegrationTest.class)
 @RunWith(Parameterized.class)
 public class ITSpannerTableTailerStressTest {
   static final String TABLE_NAME = "TEST_TABLE";

--- a/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/it/StressIntegrationTest.java
+++ b/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/it/StressIntegrationTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.watcher.it;
+
+/** Marker interface for stress tests. These are only executed during nightly builds. */
+public interface StressIntegrationTest {}

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <artifactId>google-cloud-spanner-bom</artifactId>
         <type>pom</type>
         <scope>import</scope>
-        <version>1.57.0</version>
+        <version>1.58.0</version>
       </dependency>
       
       <dependency>
@@ -158,10 +158,46 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
           <forkedProcessTimeoutInSeconds>3000</forkedProcessTimeoutInSeconds>
+          <forkCount>8</forkCount>
           <argLine>-Xmx1024m</argLine>
         </configuration>
+        <executions>
+          <execution>
+            <id>default</id>
+            <configuration>
+              <excludedGroups>com.google.cloud.spanner.watcher.it.StressIntegrationTest</excludedGroups>
+            </configuration>
+          </execution>
+          <execution>
+            <id>stress-integration-test</id>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+            <configuration>
+              <skip>${skipStressTests}</skip>
+              <groups>com.google.cloud.spanner.watcher.it.StressIntegrationTest</groups>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>no-stress-integration-tests</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <skipStressTests>true</skipStressTests>
+      </properties>
+    </profile>
+    <profile>
+      <id>stress-integration-tests</id>
+      <properties>
+        <skipStressTests>false</skipStressTests>
+      </properties>
+    </profile>
+  </profiles>
   
 </project>


### PR DESCRIPTION
The integration tests should be executed in parallel where that is possible. In addition, the stress tests should only be executed during the nightly build, and not for the PRs to reduce build time.

Fixes #43
