### PR TITLE
docs: add limitations to readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,19 @@ change events can be captured and processed in-process as part of a user
 application, or they can be published to Google Cloud Pubsub for consumption by
 any other application.
 
+More information on how to use Spanner Change Watcher and Spanner Change Publisher
+can be found here:
+* [Spanner Change Watcher](https://medium.com/@knutolavloite/cloud-spanner-change-watcher-b77ca036459c) 
+* [Spanner Change Publisher](https://medium.com/@knutolavloite/cloud-spanner-change-publisher-7fbee48f66f8)
+
 ## Spanner Change Watcher
 Spanner Change Watcher is the core framework that watches Spanner databases and
 tables for data changes and emits events when changes are detected. This
 framework can be included in existing applications and used to trigger
 functionality or processes in that application based on data change events.
+
+Spanner Change Watcher uses [commit timestamps](https://cloud.google.com/spanner/docs/commit-timestamp) to determine when a change has occurred.
+The framework cannot be used for tables that do not include a commit timestamp.
 
 See [Spanner Change Watcher README file](./google-cloud-spanner-change-watcher/README.md)
 for more information.
@@ -90,6 +98,17 @@ for the database in files stored in Google Cloud Storage.
 
 See [Spanner Change Archiver README file](./google-cloud-spanner-change-archiver/README.md)
 for more information.
+
+## Limitations
+* Spanner Change Watcher and Spanner Change Publisher use [commit timestamps](https://cloud.google.com/spanner/docs/commit-timestamp) to determine when a
+  change has occurred. They cannot be used on tables that do not include a commit timestamp.
+* Deletes are not detected, unless these are soft deletes that only update a deleted flag in the corresponding table.
+* Spanner Change Watcher polls tables for changes. Polling on larger tables can take some time and cause some delay
+  before a change is detected. The default poll interval is 1 second and is configurable.
+* Spanner Change Watcher emits changes on a row level basis, including the commit timestamp of the change. It does not
+  emit an even containing all changes of a single transaction. If that is needed, the client application will need to
+  group the row level changes together based on the commit timestamp.
+* Spanner Change Watcher is not a managed solution and does not come with Cloud Spanner's SLO. 
 
 ## Support Level
 Please feel free to report issues and send pull requests, but note that this

--- a/google-cloud-spanner-change-publisher/README.md
+++ b/google-cloud-spanner-change-publisher/README.md
@@ -8,6 +8,8 @@ tables in a database.
 Spanner Change Publisher can be included in an existing application, or it can
 be deployed as a standalone application.
 
+A further introduction to Spanner Change Publisher [can be found here](https://medium.com/@knutolavloite/cloud-spanner-change-publisher-7fbee48f66f8).
+
 ## Usage in Existing Application
 Clone, install and include the following dependency to your application to use
 Spanner Change Publisher.
@@ -198,6 +200,17 @@ Subscriber subscriber =
 subscriber.startAsync().awaitRunning();
 ```
 
+## Limitations
+* Spanner Change Publisher use [commit timestamps](https://cloud.google.com/spanner/docs/commit-timestamp) to determine when a
+  change has occurred. They cannot be used on tables that do not include a commit timestamp.
+* Deletes are not detected, unless these are soft deletes that only update a deleted flag in the corresponding table.
+* Spanner Change Publisher polls tables for changes. Polling on larger tables can take some time and cause some delay
+  before a change is detected. The default poll interval is 1 second and is configurable. It does support sharding to
+  lower the load on large tables. Take a look at the samples for Spanner Change Watcher for more information.
+* Spanner Change Publisher emits changes on a row level basis, including the commit timestamp of the change. It does not
+  emit an even containing all changes of a single transaction. If that is needed, the client application will need to
+  group the row level changes together based on the commit timestamp.
+* Spanner Change Publisher is not a managed solution and does not come with Cloud Spanner's SLO. 
 
 ## Support Level
 Please feel free to report issues and send pull requests, but note that this

--- a/google-cloud-spanner-change-watcher/README.md
+++ b/google-cloud-spanner-change-watcher/README.md
@@ -6,6 +6,8 @@ emits events when changes are detected. This framework can be included in an
 existing application and used to trigger functionality or processes in that
 application based on data change events.
 
+A further introduction to Spanner Change Watcher [can be found here](https://medium.com/@knutolavloite/cloud-spanner-change-publisher-7fbee48f66f8).
+
 ## Example Usage
 Spanner Change Watcher can be used to watch both single tables, a set of tables,
 or entire databases. Clone, install and add the dependency to your project:
@@ -73,6 +75,17 @@ watcher.startAsync().awaitRunning();
 Take a look at [Samples.java](../samples/spanner-change-watcher-samples/src/main/java/com/google/cloud/spanner/watcher/sample/Samples.java)
 for additional examples of more advanced use cases.
 
+## Limitations
+* Spanner Change Watcher and Spanner Change Publisher use [commit timestamps](https://cloud.google.com/spanner/docs/commit-timestamp) to determine when a
+  change has occurred. They cannot be used on tables that do not include a commit timestamp.
+* Deletes are not detected, unless these are soft deletes that only update a deleted flag in the corresponding table.
+* Spanner Change Watcher polls tables for changes. Polling on larger tables can take some time and cause some delay
+  before a change is detected. The default poll interval is 1 second and is configurable. It does support sharding to
+  lower the load on large tables. Take a look at the samples for more information.
+* Spanner Change Watcher emits changes on a row level basis, including the commit timestamp of the change. It does not
+  emit an even containing all changes of a single transaction. If that is needed, the client application will need to
+  group the row level changes together based on the commit timestamp.
+* Spanner Change Watcher is not a managed solution and does not come with Cloud Spanner's SLO. 
 
 ## Support Level
 Please feel free to report issues and send pull requests, but note that this


### PR DESCRIPTION
Adds documentation on the limitations to the different readme files, and a link to the Medium articles on how to use this framework.