### PR TITLE
Update Archiver Go version from 1.11 to 1.13.

### DIFF
--- a/google-cloud-spanner-change-archiver/src/main/resources/go/go.mod
+++ b/google-cloud-spanner-change-archiver/src/main/resources/go/go.mod
@@ -6,4 +6,4 @@ require (
 	cloud.google.com/go/storage v1.6.0
 )
 
-go 1.11
+go 1.13


### PR DESCRIPTION
The Go 1.11 runtime on Cloud Functions will be deprecated on August 5, 2020.