### PR TITLE
feat: add change set pollers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ tables for data changes and emits events when changes are detected. This
 framework can be included in existing applications and used to trigger
 functionality or processes in that application based on data change events.
 
-Spanner Change Watcher uses [commit timestamps](https://cloud.google.com/spanner/docs/commit-timestamp) to determine when a change has occurred.
-The framework cannot be used for tables that do not include a commit timestamp.
+Spanner Change Watcher by default uses [commit timestamps](https://cloud.google.com/spanner/docs/commit-timestamp)
+to determine when a change has occurred.
+
+The framework can also be used for tables that do not include a commit timestamp, but this does require
+the use of an additional CHANGE_SETS table that registers all read/write transactions.
 
 See [Spanner Change Watcher README file](./google-cloud-spanner-change-watcher/README.md)
 for more information.
@@ -100,23 +103,18 @@ See [Spanner Change Archiver README file](./google-cloud-spanner-change-archiver
 for more information.
 
 ## Limitations
-* Spanner Change Watcher and Spanner Change Publisher use [commit
-  timestamps](https://cloud.google.com/spanner/docs/commit-timestamp) to
-  determine when a change has occurred. They cannot be used on tables that do
-  not include a commit timestamp.
-* Deletes are not detected, unless these are soft deletes that only update a
-  deleted flag in the corresponding table.
-* Spanner Change Watcher polls tables for changes. Polling on larger tables can
-  take some time and cause some delay before a change is detected. The default
-  poll interval is 1 second and is configurable. If multiple changes happen
+* Spanner Change Watcher and Spanner Change Publisher by default use
+  [commit timestamps](https://cloud.google.com/spanner/docs/commit-timestamp) to determine when a
+  change has occurred. Tables that do not include a commit timestamp can also be monitored, but require
+  the creation of an additional CHANGE_SETS table that registers all read/write transactions.
+* Deletes are not detected, unless these are soft deletes that only update a deleted flag in the corresponding table.
+* Spanner Change Watcher polls tables for changes. Polling on larger tables can take some time and cause some delay
+  before a change is detected. The default poll interval is 1 second and is configurable. If multiple changes happen
   during a single poll interval, only the last change will be detected.
-* Spanner Change Watcher emits changes on a row level basis, including columns
-  that have not changed, and the commit timestamp of the change. It does not
-  emit an event containing all changes of a single transaction. If that is
-  needed, the client application will need to group the row level changes
-  together based on the commit timestamp.
-* Spanner Change Watcher is not a managed solution and does not come with Cloud
-  Spanner's SLO.
+* Spanner Change Watcher emits changes on a row level basis, including the commit timestamp of the change. It does not
+  emit an event containing all changes of a single transaction. If that is needed, the client application will need to
+  group the row level changes together based on the commit timestamp.
+* Spanner Change Watcher is not a managed solution and does not come with Cloud Spanner's SLO.
 
 ## Support Level
 Please feel free to report issues and send pull requests, but note that this

--- a/google-cloud-spanner-change-watcher/README.md
+++ b/google-cloud-spanner-change-watcher/README.md
@@ -70,14 +70,18 @@ Take a look at [Samples.java](../samples/spanner-change-watcher-samples/src/main
 for additional examples of more advanced use cases.
 
 ## Limitations
-* Spanner Change Watcher and Spanner Change Publisher use [commit timestamps](https://cloud.google.com/spanner/docs/commit-timestamp) to determine when a
-  change has occurred. They cannot be used on tables that do not include a commit timestamp.
+* Spanner Change Watcher and Spanner Change Publisher by default use
+  [commit timestamps](https://cloud.google.com/spanner/docs/commit-timestamp) to determine when a
+  change has occurred. Tables that do not include a commit timestamp can also be monitored, but require
+  the creation of an additional CHANGE_SETS table that registers all read/write transactions.
 * Deletes are not detected, unless these are soft deletes that only update a deleted flag in the corresponding table.
 * Spanner Change Watcher polls tables for changes. Polling on larger tables can take some time and cause some delay
   before a change is detected. The default poll interval is 1 second and is configurable. It does support sharding to
-  lower the load on large tables. Take a look at the samples for more information.
+  reduce the load on large tables. It is also possible to use an additional CHANGE_SETS table that registers all
+  read/write transactions, and only poll this table using a SpannerTableChangeSetPoller instead of polling the data tables.
+  Take a look at the samples for more information.
 * Spanner Change Watcher emits changes on a row level basis, including the commit timestamp of the change. It does not
-  emit an even containing all changes of a single transaction. If that is needed, the client application will need to
+  emit an event containing all changes of a single transaction. If that is needed, the client application will need to
   group the row level changes together based on the commit timestamp.
 * Spanner Change Watcher is not a managed solution and does not come with Cloud Spanner's SLO. 
 

--- a/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/DatabaseClientWithChangeSets.java
+++ b/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/DatabaseClientWithChangeSets.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.watcher;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.AsyncRunner;
+import com.google.cloud.spanner.AsyncTransactionManager;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.Mutation.Op;
+import com.google.cloud.spanner.ReadContext;
+import com.google.cloud.spanner.ReadOnlyTransaction;
+import com.google.cloud.spanner.SpannerException;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.TimestampBound;
+import com.google.cloud.spanner.TransactionContext;
+import com.google.cloud.spanner.TransactionManager;
+import com.google.cloud.spanner.TransactionManager.TransactionState;
+import com.google.cloud.spanner.TransactionRunner;
+import com.google.cloud.spanner.Value;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+
+/**
+ * {@link DatabaseClient} that automatically generates change set id's, adds a mutation for a change
+ * set for each read/write transaction, and adds the change set id to mutations that are written.
+ */
+public class DatabaseClientWithChangeSets implements DatabaseClient {
+  /**
+   * Interface for generating unique id's for change sets. The default implementation will use a
+   * random UUID for each change set.
+   */
+  public interface ChangeSetIdGenerator {
+    String generateChangeSetId();
+  }
+
+  /** Supplier of change set id's. */
+  public interface ChangeSetIdSupplier {
+    String getChangeSetId();
+  }
+
+  /** {@link TransactionRunner} that automatically creates a change set. */
+  public interface TransactionRunnerWithChangeSet extends TransactionRunner, ChangeSetIdSupplier {}
+
+  /** {@link TransactionManager} that automatically creates a change set. */
+  public interface TransactionManagerWithChangeSet
+      extends TransactionManager, ChangeSetIdSupplier {}
+
+  /** {@link AsyncRunner} that automatically creates a change set. */
+  public interface AsyncRunnerWithChangeSet extends AsyncRunner, ChangeSetIdSupplier {}
+
+  /** {@link AsyncTransactionManager} that automatically creates a change set. */
+  public interface AsyncTransactionManagerWithChangeSet
+      extends AsyncTransactionManager, ChangeSetIdSupplier {}
+
+  /** Default implementation of {@link ChangeSetIdGenerator} that will use random UUID's. */
+  static class RandomUUIDChangeSetIdGenerator implements ChangeSetIdGenerator {
+    static final RandomUUIDChangeSetIdGenerator INSTANCE = new RandomUUIDChangeSetIdGenerator();
+
+    private RandomUUIDChangeSetIdGenerator() {}
+
+    public String generateChangeSetId() {
+      return UUID.randomUUID().toString();
+    }
+  }
+
+  abstract class AbstractChangeSetTransaction implements ChangeSetIdSupplier {
+    final String changeSetId;
+
+    AbstractChangeSetTransaction() {
+      this.changeSetId = idGenerator.generateChangeSetId();
+    }
+
+    public String getChangeSetId() {
+      return changeSetId;
+    }
+  }
+
+  class TransactionRunnerWithChangeSetImpl extends AbstractChangeSetTransaction
+      implements TransactionRunnerWithChangeSet {
+    final TransactionRunner runner;
+
+    TransactionRunnerWithChangeSetImpl(TransactionRunner runner) {
+      this.runner = runner;
+    }
+
+    public <T> T run(TransactionCallable<T> callable) {
+      return runner.run(
+          new TransactionCallable<T>() {
+            @Override
+            public T run(TransactionContext transaction) throws Exception {
+              transaction.buffer(createChangeSetMutation(changeSetId));
+              return callable.run(transaction);
+            }
+          });
+    }
+
+    public Timestamp getCommitTimestamp() {
+      return runner.getCommitTimestamp();
+    }
+
+    public TransactionRunner allowNestedTransaction() {
+      return runner.allowNestedTransaction();
+    }
+  }
+
+  class TransactionManagerWithChangeSetImpl extends AbstractChangeSetTransaction
+      implements TransactionManagerWithChangeSet {
+    final TransactionManager manager;
+
+    TransactionManagerWithChangeSetImpl(TransactionManager manager) {
+      this.manager = manager;
+    }
+
+    public TransactionContext begin() {
+      TransactionContext context = manager.begin();
+      context.buffer(createChangeSetMutation(changeSetId));
+      return context;
+    }
+
+    public void commit() {
+      manager.commit();
+    }
+
+    public void rollback() {
+      manager.rollback();
+    }
+
+    public TransactionContext resetForRetry() {
+      TransactionContext context = manager.resetForRetry();
+      context.buffer(createChangeSetMutation(changeSetId));
+      return context;
+    }
+
+    public Timestamp getCommitTimestamp() {
+      return manager.getCommitTimestamp();
+    }
+
+    public TransactionState getState() {
+      return manager.getState();
+    }
+
+    public void close() {
+      manager.close();
+    }
+  }
+
+  class AsyncRunnerWithChangeSetImpl extends AbstractChangeSetTransaction
+      implements AsyncRunnerWithChangeSet {
+    final AsyncRunner runner;
+
+    AsyncRunnerWithChangeSetImpl(AsyncRunner runner) {
+      this.runner = runner;
+    }
+
+    @Override
+    public <R> ApiFuture<R> runAsync(AsyncWork<R> work, Executor executor) {
+      return runner.runAsync(
+          new AsyncWork<R>() {
+            @Override
+            public ApiFuture<R> doWorkAsync(TransactionContext txn) {
+              txn.buffer(createChangeSetMutation(changeSetId));
+              return work.doWorkAsync(txn);
+            }
+          },
+          executor);
+    }
+
+    public ApiFuture<Timestamp> getCommitTimestamp() {
+      return runner.getCommitTimestamp();
+    }
+  }
+
+  class AsyncTransactionManagerWithChangeSetImpl extends AbstractChangeSetTransaction
+      implements AsyncTransactionManagerWithChangeSet {
+    final AsyncTransactionManager manager;
+
+    AsyncTransactionManagerWithChangeSetImpl(AsyncTransactionManager manager) {
+      this.manager = manager;
+    }
+
+    public TransactionContextFuture beginAsync() {
+      TransactionContextFuture context = manager.beginAsync();
+      ApiFutures.addCallback(
+          context,
+          new ApiFutureCallback<TransactionContext>() {
+            @Override
+            public void onFailure(Throwable t) {}
+
+            @Override
+            public void onSuccess(TransactionContext context) {
+              context.buffer(createChangeSetMutation(changeSetId));
+            }
+          },
+          MoreExecutors.directExecutor());
+      return context;
+    }
+
+    public ApiFuture<Void> rollbackAsync() {
+      return manager.rollbackAsync();
+    }
+
+    public TransactionContextFuture resetForRetryAsync() {
+      TransactionContextFuture context = manager.resetForRetryAsync();
+      ApiFutures.addCallback(
+          context,
+          new ApiFutureCallback<TransactionContext>() {
+            @Override
+            public void onFailure(Throwable t) {}
+
+            @Override
+            public void onSuccess(TransactionContext context) {
+              context.buffer(createChangeSetMutation(changeSetId));
+            }
+          },
+          MoreExecutors.directExecutor());
+      return context;
+    }
+
+    public TransactionState getState() {
+      return manager.getState();
+    }
+
+    public void close() {
+      manager.close();
+    }
+  }
+
+  private final DatabaseClient client;
+  private final String changeSetTable;
+  private final String changeSetIdColumn;
+  private final String changeSetCommitTSColumn;
+  private final ChangeSetIdGenerator idGenerator;
+
+  /**
+   * Creates a {@link DatabaseClient} that will automatically create a change set for each
+   * read/write transaction.
+   */
+  public static DatabaseClientWithChangeSets of(DatabaseClient client) {
+    return new DatabaseClientWithChangeSets(
+        client,
+        SpannerTableChangeSetPoller.DEFAULT_CHANGE_SET_TABLE_NAME,
+        SpannerTableChangeSetPoller.DEFAULT_CHANGE_SET_ID_COLUMN,
+        SpannerTableChangeSetPoller.DEFAULT_CHANGE_SET_COMMIT_TS_COLUMN,
+        RandomUUIDChangeSetIdGenerator.INSTANCE);
+  }
+
+  private DatabaseClientWithChangeSets(
+      DatabaseClient client,
+      String changeSetTable,
+      String changeSetIdColumn,
+      String changeSetCommitTSColumn,
+      ChangeSetIdGenerator idGenerator) {
+    this.client = client;
+    this.changeSetTable = changeSetTable;
+    this.changeSetIdColumn = changeSetIdColumn;
+    this.changeSetCommitTSColumn = changeSetCommitTSColumn;
+    this.idGenerator = idGenerator;
+  }
+
+  public String newChangeSetId() {
+    return idGenerator.generateChangeSetId();
+  }
+
+  boolean containsChangeSetOperation(Iterable<Mutation> mutations) {
+    for (Mutation m : mutations) {
+      if (m.getTable().equals(changeSetTable)) {
+        if (m.getOperation() == Op.INSERT || m.getOperation() == Op.INSERT_OR_UPDATE) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  Mutation createChangeSetMutation(String changeSetId) {
+    return Mutation.newInsertOrUpdateBuilder(changeSetTable)
+        .set(changeSetIdColumn)
+        .to(changeSetId)
+        .set(changeSetCommitTSColumn)
+        .to(Value.COMMIT_TIMESTAMP)
+        .build();
+  }
+
+  Iterable<Mutation> appendChangeSetMutation(Iterable<Mutation> mutations, String changeSetId) {
+    return Iterables.concat(mutations, ImmutableList.of(createChangeSetMutation(changeSetId)));
+  }
+
+  @Override
+  public Timestamp write(Iterable<Mutation> mutations) throws SpannerException {
+    return client.write(mutations);
+  }
+
+  /** Writes a set of mutations as a change set using the given change set id. */
+  public Timestamp write(String changeSetId, Iterable<Mutation> mutations) throws SpannerException {
+    return write(appendChangeSetMutation(mutations, changeSetId));
+  }
+
+  @Override
+  public Timestamp writeAtLeastOnce(Iterable<Mutation> mutations) throws SpannerException {
+    return client.writeAtLeastOnce(mutations);
+  }
+
+  /** Writes a set of mutations at least once as a change set using the given change set id. */
+  public Timestamp writeAtLeastOnce(String changeSetId, Iterable<Mutation> mutations)
+      throws SpannerException {
+    return writeAtLeastOnce(appendChangeSetMutation(mutations, changeSetId));
+  }
+
+  /** Creates a {@link TransactionRunner} that automatically creates a change set. */
+  public TransactionRunnerWithChangeSet readWriteTransaction() {
+    return new TransactionRunnerWithChangeSetImpl(client.readWriteTransaction());
+  }
+
+  /** Creates a {@link TransactionManager} that automatically creates a change set. */
+  public TransactionManagerWithChangeSet transactionManager() {
+    return new TransactionManagerWithChangeSetImpl(client.transactionManager());
+  }
+
+  public AsyncRunnerWithChangeSet runAsync() {
+    return new AsyncRunnerWithChangeSetImpl(client.runAsync());
+  }
+
+  public AsyncTransactionManagerWithChangeSet transactionManagerAsync() {
+    return new AsyncTransactionManagerWithChangeSetImpl(client.transactionManagerAsync());
+  }
+
+  public ReadContext singleUse() {
+    return client.singleUse();
+  }
+
+  public ReadContext singleUse(TimestampBound bound) {
+    return client.singleUse(bound);
+  }
+
+  public ReadOnlyTransaction singleUseReadOnlyTransaction() {
+    return client.singleUseReadOnlyTransaction();
+  }
+
+  public ReadOnlyTransaction singleUseReadOnlyTransaction(TimestampBound bound) {
+    return client.singleUseReadOnlyTransaction(bound);
+  }
+
+  public ReadOnlyTransaction readOnlyTransaction() {
+    return client.readOnlyTransaction();
+  }
+
+  public ReadOnlyTransaction readOnlyTransaction(TimestampBound bound) {
+    return client.readOnlyTransaction(bound);
+  }
+
+  public long executePartitionedUpdate(Statement stmt) {
+    return client.executePartitionedUpdate(stmt);
+  }
+}

--- a/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerDatabaseChangeSetPoller.java
+++ b/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerDatabaseChangeSetPoller.java
@@ -1,0 +1,512 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.watcher;
+
+import com.google.api.client.util.Preconditions;
+import com.google.api.core.AbstractApiService;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.DatabaseId;
+import com.google.cloud.spanner.ErrorCode;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.SpannerExceptionFactory;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.StructReader;
+import com.google.cloud.spanner.watcher.SpannerDatabaseChangeSetPoller.Builder.TableExcluder;
+import com.google.cloud.spanner.watcher.SpannerDatabaseChangeSetPoller.Builder.TableSelecter;
+import com.google.cloud.spanner.watcher.SpannerTableChangeWatcher.RowChangeCallback;
+import com.google.cloud.spanner.watcher.SpannerUtils.LogRecordBuilder;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.threeten.bp.Duration;
+
+/**
+ * Implementation of the {@link SpannerDatabaseChangeWatcher} interface that continuously polls a
+ * change set table for new rows, and then polls the actual data tables for any changes that was
+ * part of the last seen change set. This requires all client applications to insert a new row to a
+ * CHANGE_SETS table for each read/write transaction that is executed. While this does add an extra
+ * write operation to each read/write transaction, it has two advantages:
+ *
+ * <ol>
+ *   <li>It does not require each data table to have a column that stores the last commit timestamp.
+ *       Commit timestamp columns that are filled using DML will prevent the same transaction from
+ *       reading anything from the same table for the remainder of the transaction. See
+ *       https://cloud.google.com/spanner/docs/commit-timestamp#dml.
+ *   <li>Instead of having a commit timestamp column in each data table, the data tables contain a
+ *       CHANGE_SET_ID column. This column can be of any type and can contain a random value. This
+ *       makes the column easier to index than a commit timestamp column, as an index on a truly
+ *       random id will not suffer from hotspots
+ *       (https://cloud.google.com/spanner/docs/schema-design#primary-key-prevent-hotspots).
+ * </ol>
+ *
+ * <p>Example usage for watching all tables in a database:
+ *
+ * <pre>{@code
+ * String instance = "my-instance";
+ * String database = "my-database";
+ *
+ * Spanner spanner = SpannerOptions.getDefaultInstance().getService();
+ * DatabaseId databaseId = DatabaseId.of(SpannerOptions.getDefaultProjectId(), instance, database);
+ * SpannerDatabaseChangeWatcher watcher =
+ *     SpannerDatabaseChangeSetPoller.newBuilder(spanner, databaseId).allTables().build();
+ * watcher.addCallback(
+ *     new RowChangeCallback() {
+ *       @Override
+ *       public void rowChange(TableId table, Row row, Timestamp commitTimestamp) {
+ *         System.out.printf(
+ *             "Received change for table %s: %s%n", table, row.asStruct().toString());
+ *       }
+ *     });
+ * watcher.startAsync().awaitRunning();
+ * }</pre>
+ */
+public class SpannerDatabaseChangeSetPoller extends AbstractApiService
+    implements SpannerDatabaseChangeWatcher {
+  private static final Logger logger =
+      Logger.getLogger(SpannerDatabaseChangeSetPoller.class.getName());
+
+  /** Builder for a {@link SpannerDatabaseChangeSetPoller}. */
+  public interface Builder {
+    /**
+     * Sets a specific {@link CommitTimestampRepository} to use for the {@link SpannerTableTailer}s
+     * that are watching the change set table.
+     *
+     * <p>If none is set, it will default to a {@link SpannerCommitTimestampRepository} which stores
+     * the last seen commit timestamp in a table named LAST_SEEN_COMMIT_TIMESTAMPS. The table will
+     * be created if it does not yet exist.
+     */
+    public Builder setCommitTimestampRepository(CommitTimestampRepository repository);
+
+    /**
+     * Sets the poll interval to use for this {@link SpannerDatabaseChangeSetPoller}. The default is
+     * 1 second.
+     */
+    public Builder setPollInterval(Duration interval);
+
+    /**
+     * Sets a specific {@link ScheduledExecutorService} to use for this {@link
+     * SpannerDatabaseChangeSetPoller}. This executor will be used to execute the poll queries on
+     * the tables and to call the {@link RowChangeCallback}s. The default will use a {@link
+     * ScheduledThreadPoolExecutor} with a core size equal to the number of tables that is being
+     * monitored.
+     */
+    public Builder setExecutor(ScheduledExecutorService executor);
+
+    /**
+     * Interface for selecting the tables that should be monitored by a {@link
+     * SpannerDatabaseChangeSetPoller}.
+     */
+    public interface TableSelecter {
+      /**
+       * Instructs the {@link SpannerDatabaseChangeSetPoller} to only emit changes for these
+       * specific tables.
+       */
+      Builder includeTables(String firstTable, String... furtherTables);
+
+      /**
+       * Instructs the {@link SpannerDatabaseChangeSetPoller} to emit change events for all tables
+       * in the database. Tables can be excluded by calling {@link TableExcluder#except(String...)}.
+       */
+      TableExcluder allTables();
+    }
+
+    /** Interface for excluding specific tables from a {@link SpannerDatabaseChangeSetPoller}. */
+    public interface TableExcluder extends Builder {
+      /**
+       * Instructs the {@link SpannerDatabaseChangeSetPoller} to exclude these tables from change
+       * events. This option can be used in combination with {@link TableSelecter#allTables()} to
+       * include all tables except for a specfic list.
+       */
+      Builder except(String... tables);
+    }
+
+    /** Creates a {@link SpannerDatabaseChangeSetPoller} from this builder. */
+    public SpannerDatabaseChangeSetPoller build();
+  }
+
+  /** Lists all tables with a change set id column. */
+  static final String LIST_TABLE_NAMES_STATEMENT =
+      "SELECT TABLE_NAME\n"
+          + "FROM INFORMATION_SCHEMA.TABLES\n"
+          + "WHERE TABLE_NAME NOT IN UNNEST(@excluded)\n"
+          + "AND (@allTables=TRUE OR TABLE_NAME IN UNNEST(@included))\n"
+          + "AND TABLE_CATALOG = @catalog\n"
+          + "AND TABLE_SCHEMA = @schema\n"
+          + "AND TABLE_NAME IN (SELECT TABLE_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE COLUMN_NAME=@changeSetIdColumn)";
+
+  static class BuilderImpl implements TableSelecter, TableExcluder, Builder {
+    private final Spanner spanner;
+    private final DatabaseId databaseId;
+    private final TableId changeSetTable;
+    private String catalog = "";
+    private String schema = "";
+    private String dataTableChangeSetIdColumn =
+        SpannerTableChangeSetPoller.DEFAULT_CHANGE_SET_ID_COLUMN;
+    private String changeSetTableIdColumn =
+        SpannerTableChangeSetPoller.DEFAULT_CHANGE_SET_ID_COLUMN;
+    private boolean allTables = false;
+    private List<String> includedTables = new ArrayList<>();
+    private List<String> excludedTables = new ArrayList<>();
+    private CommitTimestampRepository commitTimestampRepository;
+    private Duration pollInterval = Duration.ofSeconds(1L);
+    private ScheduledExecutorService executor;
+
+    private BuilderImpl(Spanner spanner, DatabaseId databaseId, TableId changeSetTable) {
+      this.spanner = Preconditions.checkNotNull(spanner);
+      this.databaseId = Preconditions.checkNotNull(databaseId);
+      this.changeSetTable = Preconditions.checkNotNull(changeSetTable);
+      this.commitTimestampRepository =
+          SpannerCommitTimestampRepository.newBuilder(spanner, databaseId).build();
+    }
+
+    @Override
+    public TableExcluder allTables() {
+      Preconditions.checkState(
+          includedTables.isEmpty(), "Cannot include specific tables in combination with allTables");
+      this.allTables = true;
+      return this;
+    }
+
+    @Override
+    public Builder includeTables(String firstTable, String... otherTables) {
+      Preconditions.checkNotNull(firstTable);
+      Preconditions.checkState(
+          !allTables, "Cannot include specific tables in combination with allTables");
+      includedTables.add(firstTable);
+      includedTables.addAll(Arrays.asList(otherTables));
+      return this;
+    }
+
+    @Override
+    public Builder except(String... excludedTables) {
+      this.excludedTables.addAll(Arrays.asList(excludedTables));
+      return this;
+    }
+
+    /**
+     * Sets the name of the column that contains the change set id in the data table (the table that
+     * is being watched for changes).
+     */
+    public Builder setDataTableChangeSetIdColumn(String column) {
+      this.dataTableChangeSetIdColumn = Preconditions.checkNotNull(column);
+      return this;
+    }
+
+    /**
+     * Sets the name of the column that contains the change set id in the change set table (the
+     * table registering all transactions that should be watched).
+     */
+    public Builder setChangeSetTableIdColumn(String column) {
+      this.changeSetTableIdColumn = Preconditions.checkNotNull(column);
+      return this;
+    }
+
+    @Override
+    public Builder setCommitTimestampRepository(CommitTimestampRepository repository) {
+      this.commitTimestampRepository = Preconditions.checkNotNull(repository);
+      return this;
+    }
+
+    /**
+     * Sets the poll interval to use for this {@link SpannerDatabaseChangeSetPoller}. The default is
+     * 1 second.
+     */
+    @Override
+    public Builder setPollInterval(Duration interval) {
+      this.pollInterval = Preconditions.checkNotNull(interval);
+      return this;
+    }
+
+    @Override
+    public Builder setExecutor(ScheduledExecutorService executor) {
+      this.executor = Preconditions.checkNotNull(executor);
+      return this;
+    }
+
+    /** Creates a {@link SpannerDatabaseChangeSetPoller} from this builder. */
+    @Override
+    public SpannerDatabaseChangeSetPoller build() {
+      return new SpannerDatabaseChangeSetPoller(this);
+    }
+  }
+
+  /** Creates a builder for a {@link SpannerDatabaseChangeSetPoller}. */
+  public static TableSelecter newBuilder(Spanner spanner, DatabaseId databaseId) {
+    return new BuilderImpl(
+        spanner,
+        databaseId,
+        TableId.of(databaseId, SpannerTableChangeSetPoller.DEFAULT_CHANGE_SET_TABLE_NAME));
+  }
+
+  /** Creates a builder for a {@link SpannerDatabaseChangeSetPoller}. */
+  public static TableSelecter newBuilder(
+      Spanner spanner, DatabaseId databaseId, TableId changeSetTable) {
+    return new BuilderImpl(spanner, databaseId, changeSetTable);
+  }
+
+  private final Object lock = new Object();
+  private final Spanner spanner;
+  private final DatabaseId databaseId;
+  private final TableId changeSetTable;
+  private final String catalog;
+  private final String schema;
+  private final boolean allTables;
+  private final ImmutableList<String> includedTables;
+  private final ImmutableList<String> excludedTables;
+  private final String dataTableChangeSetIdColumn;
+  private final String changeSetTableIdColumn;
+  private final CommitTimestampRepository commitTimestampRepository;
+  private final Duration pollInterval;
+  private final ScheduledExecutorService executor;
+  private final boolean isOwnedExecutor;
+  private ImmutableList<TableId> tables;
+  private Map<TableId, SpannerTableChangeWatcher> watchers;
+  private final List<RowChangeCallback> callbacks = new LinkedList<>();
+
+  private SpannerDatabaseChangeSetPoller(BuilderImpl builder) {
+    this.spanner = builder.spanner;
+    this.databaseId = builder.databaseId;
+    this.changeSetTable = builder.changeSetTable;
+    this.catalog = builder.catalog;
+    this.schema = builder.schema;
+    this.allTables = builder.allTables;
+    this.includedTables = ImmutableList.copyOf(builder.includedTables);
+    this.excludedTables =
+        ImmutableList.<String>builder()
+            .addAll(builder.excludedTables)
+            .add(builder.changeSetTable.getTable())
+            .build();
+    this.dataTableChangeSetIdColumn = builder.dataTableChangeSetIdColumn;
+    this.changeSetTableIdColumn = builder.changeSetTableIdColumn;
+    this.commitTimestampRepository = builder.commitTimestampRepository;
+    this.pollInterval = builder.pollInterval;
+    if (builder.executor == null) {
+      isOwnedExecutor = true;
+      executor = new ScheduledThreadPoolExecutor(1);
+    } else {
+      isOwnedExecutor = false;
+      executor = builder.executor;
+    }
+  }
+
+  private ImmutableList<TableId> findTableNames(DatabaseClient client) {
+    Statement statement =
+        Statement.newBuilder(LIST_TABLE_NAMES_STATEMENT)
+            .bind("excluded")
+            .toStringArray(excludedTables)
+            .bind("allTables")
+            .to(allTables)
+            .bind("included")
+            .toStringArray(includedTables)
+            .bind("schema")
+            .to(schema)
+            .bind("catalog")
+            .to(catalog)
+            .bind("changeSetIdColumn")
+            .to(dataTableChangeSetIdColumn)
+            .build();
+    ImmutableList<TableId> tables =
+        client
+            .singleUse()
+            .executeQueryAsync(statement)
+            .toList(
+                new Function<StructReader, TableId>() {
+                  @Override
+                  public TableId apply(StructReader input) {
+                    return TableId.newBuilder(databaseId, input.getString(0))
+                        .setCatalog(catalog)
+                        .setSchema(schema)
+                        .build();
+                  }
+                });
+    // Check that all tables that were explicitly included were returned by allTableNames
+    // and are valid to use with this poller, i.e. they have a column with the name of the
+    // dataTableChangeSetIdColumn.
+    for (String includedTable : includedTables) {
+      if (!tables.contains(
+          TableId.newBuilder(databaseId, includedTable)
+              .setCatalog(catalog)
+              .setSchema(schema)
+              .build())) {
+        throw SpannerExceptionFactory.newSpannerException(
+            ErrorCode.NOT_FOUND,
+            String.format(
+                "Table `%s` was explicitly included for this SpannerDatabaseChangeSetPoller, but either the table was not found or it does not contain a column with the name %s.",
+                includedTable, dataTableChangeSetIdColumn));
+      }
+    }
+    return tables;
+  }
+
+  @Override
+  public void addCallback(RowChangeCallback callback) {
+    Preconditions.checkState(state() == State.NEW);
+    callbacks.add(callback);
+  }
+
+  @Override
+  protected void doStart() {
+    executor.execute(
+        new Runnable() {
+          @Override
+          public void run() {
+            try {
+              ImmutableList<TableId> tables = getTables();
+              if (tables.isEmpty()) {
+                throw SpannerExceptionFactory.newSpannerException(
+                    ErrorCode.NOT_FOUND,
+                    String.format(
+                        "No suitable tables found for watcher for database %s", databaseId));
+              }
+              if (isOwnedExecutor) {
+                ((ScheduledThreadPoolExecutor) executor).setCorePoolSize(tables.size());
+              }
+              synchronized (lock) {
+                if (watchers == null) {
+                  initWatchersLocked();
+                }
+                for (SpannerTableChangeWatcher watcher : watchers.values()) {
+                  watcher.startAsync();
+                }
+              }
+            } catch (Throwable t) {
+              logger.log(
+                  LogRecordBuilder.of(
+                      Level.WARNING, "Failed to start watcher for database {0}", databaseId, t));
+              notifyFailed(t);
+            }
+          }
+        });
+  }
+
+  @Override
+  protected void doStop() {
+    synchronized (lock) {
+      for (SpannerTableChangeWatcher c : watchers.values()) {
+        c.stopAsync();
+      }
+    }
+  }
+
+  @Override
+  public DatabaseId getDatabaseId() {
+    return databaseId;
+  }
+
+  @Override
+  public ImmutableList<TableId> getTables() {
+    synchronized (lock) {
+      if (tables == null) {
+        tables = findTableNames(spanner.getDatabaseClient(databaseId));
+      }
+      return tables;
+    }
+  }
+
+  private void initWatchersLocked() {
+    watchers = new HashMap<>(tables.size());
+    for (TableId table : tables) {
+      SpannerTableChangeWatcher watcher =
+          SpannerTableChangeSetPoller.newBuilder(spanner, changeSetTable, table)
+              .setDataTableChangeSetIdColumn(dataTableChangeSetIdColumn)
+              .setChangeSetTableIdColumn(changeSetTableIdColumn)
+              .setCommitTimestampRepository(commitTimestampRepository)
+              .setPollInterval(pollInterval)
+              .setExecutor(executor)
+              .build();
+      for (RowChangeCallback callback : callbacks) {
+        watcher.addCallback(callback);
+      }
+      watcher.addListener(
+          new Listener() {
+            @Override
+            public void failed(State from, Throwable failure) {
+              synchronized (lock) {
+                // Try to stop all watchers that are still running.
+                for (SpannerTableChangeWatcher c : watchers.values()) {
+                  if (c.state() != State.FAILED) {
+                    c.stopAsync();
+                  }
+                }
+                for (SpannerTableChangeWatcher c : watchers.values()) {
+                  if (c.state() == State.STOPPING) {
+                    c.awaitTerminated();
+                  }
+                }
+                if (isOwnedExecutor) {
+                  executor.shutdown();
+                }
+                logger.log(
+                    LogRecordBuilder.of(
+                        Level.WARNING,
+                        "Watcher failed to start for database {0}",
+                        databaseId,
+                        failure));
+                notifyFailed(failure);
+              }
+            }
+
+            @Override
+            public void running() {
+              synchronized (lock) {
+                if (state() == State.RUNNING) {
+                  return;
+                }
+                for (SpannerTableChangeWatcher c : watchers.values()) {
+                  if (c.state() != State.RUNNING) {
+                    return;
+                  }
+                }
+                logger.log(Level.INFO, "Watcher started successfully for database {0}", databaseId);
+                notifyStarted();
+              }
+            }
+
+            @Override
+            public void terminated(State from) {
+              synchronized (lock) {
+                if (state() == State.TERMINATED) {
+                  return;
+                }
+                for (SpannerTableChangeWatcher c : watchers.values()) {
+                  if (c.state() != State.TERMINATED) {
+                    return;
+                  }
+                }
+                if (isOwnedExecutor) {
+                  executor.shutdown();
+                }
+                logger.log(Level.INFO, "Watcher terminated for database {0}", databaseId);
+                notifyStopped();
+              }
+            }
+          },
+          MoreExecutors.directExecutor());
+      watchers.put(table, watcher);
+    }
+  }
+}

--- a/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerTableChangeSetPoller.java
+++ b/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerTableChangeSetPoller.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.watcher;
+
+import com.google.api.core.AbstractApiService;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.Value;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.logging.Logger;
+import org.threeten.bp.Duration;
+
+/**
+ * Implementation of the {@link SpannerTableChangeWatcher} interface that continuously polls a
+ * change set table for new rows, and then polls an actual data table for any changes that was part
+ * of the last seen change set. This requires all client applications to insert a new row to a
+ * CHANGE_SETS table for each read/write transaction that is executed. While this does add an extra
+ * write operation to each read/write transaction, it has two advantages:
+ *
+ * <ol>
+ *   <li>It does not require each data table to have a column that stores the last commit timestamp.
+ *       Commit timestamp columns that are filled using DML will prevent the same transaction from
+ *       reading anything from the same table for the remainder of the transaction. See
+ *       https://cloud.google.com/spanner/docs/commit-timestamp#dml.
+ *   <li>Instead of having a commit timestamp column in each data table, the data tables contain a
+ *       CHANGE_SET_ID column. This column can be of any type and can contain a random value. This
+ *       makes the column easier to index than a commit timestamp column, as an index on a truly
+ *       random id will not suffer from hotspots
+ *       (https://cloud.google.com/spanner/docs/schema-design#primary-key-prevent-hotspots).
+ * </ol>
+ *
+ * <p>Usage:
+ *
+ * <pre>{@code
+ * String instance = "my-instance";
+ * String database = "my-database";
+ * String table = "MY_TABLE";
+ *
+ * Spanner spanner = SpannerOptions.getDefaultInstance().getService();
+ * TableId tableId =
+ *     TableId.of(DatabaseId.of(SpannerOptions.getDefaultProjectId(), instance, database), table);
+ * SpannerTableChangeSetPoller watcher = SpannerTableChangeSetPoller.newBuilder(spanner, tableId).build();
+ * watcher.addCallback(
+ *     new RowChangeCallback() {
+ *       @Override
+ *       public void rowChange(TableId table, Row row, Timestamp commitTimestamp) {
+ *         System.out.printf(
+ *             "Received change for table %s: %s%n", table, row.asStruct().toString());
+ *       }
+ *     });
+ * watcher.startAsync().awaitRunning();
+ * }</pre>
+ */
+public class SpannerTableChangeSetPoller extends AbstractApiService
+    implements SpannerTableChangeWatcher {
+  static final Logger logger = Logger.getLogger(SpannerTableChangeSetPoller.class.getName());
+  static final String POLL_QUERY = "SELECT *\nFROM %s\nWHERE `%s`=@changeSet";
+  static final String DEFAULT_CHANGE_SET_TABLE_NAME = "CHANGE_SETS";
+  static final String DEFAULT_CHANGE_SET_ID_COLUMN = "CHANGE_SET_ID";
+  static final String DEFAULT_CHANGE_SET_COMMIT_TS_COLUMN = "COMMIT_TIMESTAMP";
+
+  /** Builder for a {@link SpannerTableChangeSetPoller}. */
+  public static class Builder {
+    private final SpannerTableTailer.Builder tailerBuilder;
+    private final Spanner spanner;
+    private final TableId table;
+    private String dataTableChangeSetIdColumn = DEFAULT_CHANGE_SET_ID_COLUMN;
+    private String changeSetTableIdColumn = DEFAULT_CHANGE_SET_ID_COLUMN;
+
+    Builder(Spanner spanner, TableId changeSetsTable, TableId table) {
+      this.tailerBuilder =
+          SpannerTableTailer.newBuilder(spanner, changeSetsTable)
+              .setShardProvider(
+                  new ShardProvider() {
+                    @Override
+                    public Value getShardValue() {
+                      return Value.string(table.getFullName());
+                    }
+
+                    @Override
+                    public void appendShardFilter(
+                        com.google.cloud.spanner.Statement.Builder statementBuilder) {
+                      // We do not filter the CHANGE_SETS poll queries.
+                    }
+                  });
+      this.spanner = spanner;
+      this.table = table;
+    }
+
+    /**
+     * Sets the name of the column that contains the change set id in the data table (the table that
+     * is being watched for changes).
+     */
+    public Builder setDataTableChangeSetIdColumn(String column) {
+      this.dataTableChangeSetIdColumn = Preconditions.checkNotNull(column);
+      return this;
+    }
+
+    /**
+     * Sets the name of the column that contains the change set id in the change set table (the
+     * table registering all transactions that should be watched).
+     */
+    public Builder setChangeSetTableIdColumn(String column) {
+      this.changeSetTableIdColumn = Preconditions.checkNotNull(column);
+      return this;
+    }
+
+    /**
+     * Sets the {@link CommitTimestampRepository} to use for the {@link SpannerTableTailer} that is
+     * watching the change set table.
+     *
+     * <p>If none is set, it will default to a {@link SpannerCommitTimestampRepository} which stores
+     * the last seen commit timestamp in a table named LAST_SEEN_COMMIT_TIMESTAMPS. The table will
+     * be created if it does not yet exist.
+     */
+    public Builder setCommitTimestampRepository(CommitTimestampRepository repository) {
+      this.tailerBuilder.setCommitTimestampRepository(repository);
+      return this;
+    }
+
+    /** Sets the poll interval for the table. Defaults to 1 second. */
+    public Builder setPollInterval(Duration interval) {
+      this.tailerBuilder.setPollInterval(interval);
+      return this;
+    }
+
+    /** Sets the executor to use for polling for changes. */
+    public Builder setExecutor(ScheduledExecutorService executor) {
+      this.tailerBuilder.setExecutor(executor);
+      return this;
+    }
+
+    /** Creates the {@link SpannerTableChangeSetPoller}. */
+    public SpannerTableChangeSetPoller build() {
+      return new SpannerTableChangeSetPoller(this);
+    }
+  }
+
+  /**
+   * Creates a new {@link SpannerTableChangeSetPoller.Builder} for the given table. The poller will
+   * assume that all change sets are stored in a table called CHANGE_SETS.
+   */
+  public static Builder newBuilder(Spanner spanner, TableId table) {
+    return new Builder(
+        spanner, TableId.of(table.getDatabaseId(), DEFAULT_CHANGE_SET_TABLE_NAME), table);
+  }
+
+  /**
+   * Creates a new {@link SpannerTableChangeSetPoller.Builder} for the given table and using the
+   * specified change set table.
+   */
+  public static Builder newBuilder(Spanner spanner, TableId changeSetTable, TableId table) {
+    return new Builder(spanner, changeSetTable, table);
+  }
+
+  private final SpannerTableChangeWatcher changeSetWatcher;
+  private final TableId table;
+  private final String dataTableChangeSetIdColumn;
+  private final String changeSetTableIdColumn;
+  private final List<RowChangeCallback> callbacks = new LinkedList<>();
+  private final DatabaseClient client;
+
+  private SpannerTableChangeSetPoller(Builder builder) {
+    this.changeSetWatcher = builder.tailerBuilder.build();
+    this.table = builder.table;
+    this.dataTableChangeSetIdColumn = builder.dataTableChangeSetIdColumn;
+    this.changeSetTableIdColumn = builder.changeSetTableIdColumn;
+    this.client = builder.spanner.getDatabaseClient(builder.table.getDatabaseId());
+  }
+
+  @Override
+  public TableId getTable() {
+    return changeSetWatcher.getTable();
+  }
+
+  @Override
+  public void addCallback(RowChangeCallback callback) {
+    Preconditions.checkState(state() == State.NEW);
+    callbacks.add(callback);
+  }
+
+  @Override
+  protected void doStart() {
+    changeSetWatcher.addCallback(
+        new RowChangeCallback() {
+          @Override
+          public void rowChange(TableId table, Row row, Timestamp commitTimestamp) {
+            pollTableForChanges(row.getString(changeSetTableIdColumn), commitTimestamp);
+          }
+        });
+    changeSetWatcher.addListener(
+        new Listener() {
+          @Override
+          public void failed(State from, Throwable failure) {
+            SpannerTableChangeSetPoller.this.notifyFailed(failure);
+          }
+
+          @Override
+          public void running() {
+            SpannerTableChangeSetPoller.this.notifyStarted();
+          }
+
+          @Override
+          public void terminated(State from) {
+            SpannerTableChangeSetPoller.this.notifyStopped();
+          }
+        },
+        MoreExecutors.directExecutor());
+    changeSetWatcher.startAsync();
+  }
+
+  void pollTableForChanges(String changeSet, Timestamp commitTimestamp) {
+    Statement.Builder statementBuilder =
+        Statement.newBuilder(
+            String.format(POLL_QUERY, table.getSqlIdentifier(), dataTableChangeSetIdColumn));
+    try (ResultSet rs =
+        client.singleUse().executeQuery(statementBuilder.bind("changeSet").to(changeSet).build())) {
+      while (rs.next()) {
+        for (RowChangeCallback callback : callbacks) {
+          callback.rowChange(table, new RowImpl(rs), commitTimestamp);
+        }
+      }
+    }
+  }
+
+  @Override
+  protected void doStop() {
+    changeSetWatcher.stopAsync();
+  }
+}

--- a/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/it/ITSpannerDatabaseChangeSetPollerTest.java
+++ b/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/it/ITSpannerDatabaseChangeSetPollerTest.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.watcher.it;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.Database;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.Key;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.Value;
+import com.google.cloud.spanner.watcher.SpannerCommitTimestampRepository;
+import com.google.cloud.spanner.watcher.SpannerDatabaseChangeSetPoller;
+import com.google.cloud.spanner.watcher.SpannerDatabaseChangeWatcher;
+import com.google.cloud.spanner.watcher.SpannerTableChangeWatcher.Row;
+import com.google.cloud.spanner.watcher.SpannerTableChangeWatcher.RowChangeCallback;
+import com.google.cloud.spanner.watcher.TableId;
+import com.google.cloud.spanner.watcher.it.SpannerTestHelper.ITSpannerEnv;
+import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.threeten.bp.Duration;
+
+@RunWith(JUnit4.class)
+public class ITSpannerDatabaseChangeSetPollerTest {
+  private static final Logger logger =
+      Logger.getLogger(ITSpannerDatabaseChangeSetPollerTest.class.getName());
+  private static final ITSpannerEnv env = new ITSpannerEnv();
+  private static Database database;
+  private final Queue<Struct> receivedChanges = new ConcurrentLinkedQueue<>();
+  private volatile Timestamp lastCommitTimestamp;
+  private volatile CountDownLatch latch = new CountDownLatch(0);
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    SpannerTestHelper.setupSpanner(env);
+    database =
+        env.createTestDb(
+            Arrays.asList(
+                "CREATE TABLE NUMBERS1 (ID INT64 NOT NULL, NAME STRING(100), CHANGE_SET_ID STRING(MAX)) PRIMARY KEY (ID)",
+                "CREATE TABLE NUMBERS2 (ID INT64 NOT NULL, NAME STRING(100), CHANGE_SET_ID STRING(MAX)) PRIMARY KEY (ID)",
+                "CREATE TABLE CHANGE_SETS (CHANGE_SET_ID STRING(MAX), COMMIT_TIMESTAMP TIMESTAMP OPTIONS (allow_commit_timestamp=true)) PRIMARY KEY (CHANGE_SET_ID)",
+                "CREATE INDEX IDX_NUMBERS1_CHANGE_SET ON NUMBERS1 (CHANGE_SET_ID)",
+                "CREATE INDEX IDX_NUMBERS2_CHANGE_SET ON NUMBERS2 (CHANGE_SET_ID)"));
+    logger.info(String.format("Created database %s", database.getId().toString()));
+  }
+
+  @AfterClass
+  public static void teardown() {
+    SpannerTestHelper.teardownSpanner(env);
+  }
+
+  @Test
+  public void testSpannerTailer() throws Exception {
+    Spanner spanner = env.getSpanner();
+    SpannerDatabaseChangeWatcher watcher =
+        SpannerDatabaseChangeSetPoller.newBuilder(spanner, database.getId())
+            .allTables()
+            .setPollInterval(Duration.ofMillis(10L))
+            .setCommitTimestampRepository(
+                SpannerCommitTimestampRepository.newBuilder(spanner, database.getId())
+                    .setInitialCommitTimestamp(Timestamp.MIN_VALUE)
+                    .build())
+            .build();
+    watcher.addCallback(
+        new RowChangeCallback() {
+          @Override
+          public void rowChange(TableId table, Row row, Timestamp commitTimestamp) {
+            logger.info(
+                String.format(
+                    "Received changed for table %s: %s", table, row.asStruct().toString()));
+            receivedChanges.add(row.asStruct());
+            lastCommitTimestamp = commitTimestamp;
+            latch.countDown();
+          }
+        });
+    watcher.startAsync().awaitRunning();
+
+    DatabaseClient client = spanner.getDatabaseClient(database.getId());
+    latch = new CountDownLatch(3);
+    String changeSetId = UUID.randomUUID().toString();
+    Timestamp commitTs =
+        client.writeAtLeastOnce(
+            Arrays.asList(
+                Mutation.newInsertOrUpdateBuilder("CHANGE_SETS")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .set("COMMIT_TIMESTAMP")
+                    .to(Value.COMMIT_TIMESTAMP)
+                    .build(),
+                Mutation.newInsertOrUpdateBuilder("NUMBERS1")
+                    .set("ID")
+                    .to(1L)
+                    .set("NAME")
+                    .to("ONE")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build(),
+                Mutation.newInsertOrUpdateBuilder("NUMBERS2")
+                    .set("ID")
+                    .to(2L)
+                    .set("NAME")
+                    .to("TWO")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build(),
+                Mutation.newInsertOrUpdateBuilder("NUMBERS1")
+                    .set("ID")
+                    .to(3L)
+                    .set("NAME")
+                    .to("THREE")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build()));
+
+    List<Struct> inserts = drainChanges();
+    assertThat(inserts).hasSize(3);
+    assertThat(inserts)
+        .containsExactly(
+            Struct.newBuilder()
+                .set("ID")
+                .to(1L)
+                .set("NAME")
+                .to("ONE")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build(),
+            Struct.newBuilder()
+                .set("ID")
+                .to(2L)
+                .set("NAME")
+                .to("TWO")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build(),
+            Struct.newBuilder()
+                .set("ID")
+                .to(3L)
+                .set("NAME")
+                .to("THREE")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build());
+    assertThat(lastCommitTimestamp).isEqualTo(commitTs);
+
+    latch = new CountDownLatch(2);
+    changeSetId = UUID.randomUUID().toString();
+    commitTs =
+        client.writeAtLeastOnce(
+            Arrays.asList(
+                Mutation.newInsertOrUpdateBuilder("CHANGE_SETS")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .set("COMMIT_TIMESTAMP")
+                    .to(Value.COMMIT_TIMESTAMP)
+                    .build(),
+                Mutation.newInsertOrUpdateBuilder("NUMBERS2")
+                    .set("ID")
+                    .to(4L)
+                    .set("NAME")
+                    .to("FOUR")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build(),
+                Mutation.newInsertOrUpdateBuilder("NUMBERS1")
+                    .set("ID")
+                    .to(5L)
+                    .set("NAME")
+                    .to("FIVE")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build()));
+
+    inserts = drainChanges();
+    assertThat(inserts).hasSize(2);
+    assertThat(inserts)
+        .containsExactly(
+            Struct.newBuilder()
+                .set("ID")
+                .to(4L)
+                .set("NAME")
+                .to("FOUR")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build(),
+            Struct.newBuilder()
+                .set("ID")
+                .to(5L)
+                .set("NAME")
+                .to("FIVE")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build());
+    assertThat(lastCommitTimestamp).isEqualTo(commitTs);
+
+    latch = new CountDownLatch(2);
+    changeSetId = UUID.randomUUID().toString();
+    commitTs =
+        client.writeAtLeastOnce(
+            Arrays.asList(
+                Mutation.newInsertOrUpdateBuilder("CHANGE_SETS")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .set("COMMIT_TIMESTAMP")
+                    .to(Value.COMMIT_TIMESTAMP)
+                    .build(),
+                Mutation.newUpdateBuilder("NUMBERS1")
+                    .set("ID")
+                    .to(1L)
+                    .set("NAME")
+                    .to("one")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build(),
+                Mutation.newUpdateBuilder("NUMBERS1")
+                    .set("ID")
+                    .to(5L)
+                    .set("NAME")
+                    .to("five")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build()));
+
+    List<Struct> updates = drainChanges();
+    assertThat(updates).hasSize(2);
+    assertThat(updates)
+        .containsExactly(
+            Struct.newBuilder()
+                .set("ID")
+                .to(1L)
+                .set("NAME")
+                .to("one")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build(),
+            Struct.newBuilder()
+                .set("ID")
+                .to(5L)
+                .set("NAME")
+                .to("five")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build());
+    assertThat(lastCommitTimestamp).isEqualTo(commitTs);
+
+    // Verify that deletes are not picked up by the poller.
+    commitTs =
+        client.writeAtLeastOnce(
+            Arrays.asList(
+                Mutation.delete("NUMBERS2", Key.of(2L)), Mutation.delete("NUMBERS1", Key.of(3L))));
+    Thread.sleep(500L);
+    assertThat(receivedChanges).isEmpty();
+    watcher.stopAsync().awaitTerminated();
+  }
+
+  private ImmutableList<Struct> drainChanges() throws Exception {
+    assertThat(latch.await(5L, TimeUnit.SECONDS)).isTrue();
+    ImmutableList<Struct> changes = ImmutableList.copyOf(receivedChanges);
+    receivedChanges.clear();
+    return changes;
+  }
+}

--- a/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/it/ITSpannerTableChangeSetPollerTest.java
+++ b/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/it/ITSpannerTableChangeSetPollerTest.java
@@ -1,0 +1,985 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.watcher.it;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.Timestamp;
+import com.google.cloud.spanner.AbortedException;
+import com.google.cloud.spanner.AsyncRunner.AsyncWork;
+import com.google.cloud.spanner.AsyncTransactionManager.TransactionContextFuture;
+import com.google.cloud.spanner.Database;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.Key;
+import com.google.cloud.spanner.KeySet;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.TransactionContext;
+import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
+import com.google.cloud.spanner.Value;
+import com.google.cloud.spanner.watcher.DatabaseClientWithChangeSets;
+import com.google.cloud.spanner.watcher.DatabaseClientWithChangeSets.AsyncRunnerWithChangeSet;
+import com.google.cloud.spanner.watcher.DatabaseClientWithChangeSets.AsyncTransactionManagerWithChangeSet;
+import com.google.cloud.spanner.watcher.DatabaseClientWithChangeSets.TransactionManagerWithChangeSet;
+import com.google.cloud.spanner.watcher.DatabaseClientWithChangeSets.TransactionRunnerWithChangeSet;
+import com.google.cloud.spanner.watcher.SpannerCommitTimestampRepository;
+import com.google.cloud.spanner.watcher.SpannerTableChangeSetPoller;
+import com.google.cloud.spanner.watcher.SpannerTableChangeWatcher.Row;
+import com.google.cloud.spanner.watcher.SpannerTableChangeWatcher.RowChangeCallback;
+import com.google.cloud.spanner.watcher.TableId;
+import com.google.cloud.spanner.watcher.it.SpannerTestHelper.ITSpannerEnv;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.threeten.bp.Duration;
+
+@RunWith(JUnit4.class)
+public class ITSpannerTableChangeSetPollerTest {
+  private static final Logger logger =
+      Logger.getLogger(ITSpannerTableChangeSetPollerTest.class.getName());
+  private static final ITSpannerEnv env = new ITSpannerEnv();
+  private static Database database;
+  private final Queue<Struct> receivedChanges = new ConcurrentLinkedQueue<>();
+  private volatile Timestamp lastCommitTimestamp;
+  private volatile CountDownLatch latch = new CountDownLatch(0);
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    SpannerTestHelper.setupSpanner(env);
+    database =
+        env.createTestDb(
+            ImmutableList.of(
+                "CREATE TABLE NUMBERS (ID INT64 NOT NULL, NAME STRING(100), CHANGE_SET_ID STRING(MAX)) PRIMARY KEY (ID)",
+                "CREATE TABLE CHANGE_SETS (CHANGE_SET_ID STRING(MAX), COMMIT_TIMESTAMP TIMESTAMP OPTIONS (allow_commit_timestamp=true)) PRIMARY KEY (CHANGE_SET_ID)",
+                "CREATE INDEX IDX_NUMBERS_CHANGE_SET ON NUMBERS (CHANGE_SET_ID)"));
+    logger.info(String.format("Created database %s", database.getId().toString()));
+  }
+
+  @AfterClass
+  public static void teardown() {
+    SpannerTestHelper.teardownSpanner(env);
+  }
+
+  @Before
+  public void deleteRowsInNumbers() {
+    Spanner spanner = env.getSpanner();
+    DatabaseClient client = spanner.getDatabaseClient(database.getId());
+    client.writeAtLeastOnce(ImmutableList.of(Mutation.delete("NUMBERS", KeySet.all())));
+  }
+
+  @Test
+  public void testSpannerChangeSetPoller() throws Exception {
+    Spanner spanner = env.getSpanner();
+    SpannerTableChangeSetPoller poller =
+        SpannerTableChangeSetPoller.newBuilder(spanner, TableId.of(database.getId(), "NUMBERS"))
+            .setPollInterval(Duration.ofMillis(10L))
+            .setCommitTimestampRepository(
+                SpannerCommitTimestampRepository.newBuilder(spanner, database.getId())
+                    .setInitialCommitTimestamp(Timestamp.MIN_VALUE)
+                    .build())
+            .build();
+    poller.addCallback(
+        new RowChangeCallback() {
+          @Override
+          public void rowChange(TableId table, Row row, Timestamp commitTimestamp) {
+            logger.info(
+                String.format(
+                    "Received changed for table %s: %s", table, row.asStruct().toString()));
+            receivedChanges.add(row.asStruct());
+            lastCommitTimestamp = commitTimestamp;
+            latch.countDown();
+          }
+        });
+    poller.startAsync().awaitRunning();
+
+    DatabaseClient client = spanner.getDatabaseClient(database.getId());
+    latch = new CountDownLatch(3);
+    String changeSetId = UUID.randomUUID().toString();
+    Timestamp commitTs =
+        client.writeAtLeastOnce(
+            Arrays.asList(
+                Mutation.newInsertOrUpdateBuilder("CHANGE_SETS")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .set("COMMIT_TIMESTAMP")
+                    .to(Value.COMMIT_TIMESTAMP)
+                    .build(),
+                Mutation.newInsertOrUpdateBuilder("NUMBERS")
+                    .set("ID")
+                    .to(1L)
+                    .set("NAME")
+                    .to("ONE")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build(),
+                Mutation.newInsertOrUpdateBuilder("NUMBERS")
+                    .set("ID")
+                    .to(2L)
+                    .set("NAME")
+                    .to("TWO")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build(),
+                Mutation.newInsertOrUpdateBuilder("NUMBERS")
+                    .set("ID")
+                    .to(3L)
+                    .set("NAME")
+                    .to("THREE")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build()));
+
+    List<Struct> inserts = drainChanges();
+    assertThat(inserts).hasSize(3);
+    assertThat(inserts)
+        .containsExactly(
+            Struct.newBuilder()
+                .set("ID")
+                .to(1L)
+                .set("NAME")
+                .to("ONE")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build(),
+            Struct.newBuilder()
+                .set("ID")
+                .to(2L)
+                .set("NAME")
+                .to("TWO")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build(),
+            Struct.newBuilder()
+                .set("ID")
+                .to(3L)
+                .set("NAME")
+                .to("THREE")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build());
+    assertThat(lastCommitTimestamp).isEqualTo(commitTs);
+
+    latch = new CountDownLatch(2);
+    changeSetId = UUID.randomUUID().toString();
+    commitTs =
+        client.writeAtLeastOnce(
+            Arrays.asList(
+                Mutation.newInsertOrUpdateBuilder("CHANGE_SETS")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .set("COMMIT_TIMESTAMP")
+                    .to(Value.COMMIT_TIMESTAMP)
+                    .build(),
+                Mutation.newInsertOrUpdateBuilder("NUMBERS")
+                    .set("ID")
+                    .to(4L)
+                    .set("NAME")
+                    .to("FOUR")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build(),
+                Mutation.newInsertOrUpdateBuilder("NUMBERS")
+                    .set("ID")
+                    .to(5L)
+                    .set("NAME")
+                    .to("FIVE")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build()));
+
+    inserts = drainChanges();
+    assertThat(inserts).hasSize(2);
+    assertThat(inserts)
+        .containsExactly(
+            Struct.newBuilder()
+                .set("ID")
+                .to(4L)
+                .set("NAME")
+                .to("FOUR")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build(),
+            Struct.newBuilder()
+                .set("ID")
+                .to(5L)
+                .set("NAME")
+                .to("FIVE")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build());
+    assertThat(lastCommitTimestamp).isEqualTo(commitTs);
+
+    latch = new CountDownLatch(2);
+    changeSetId = UUID.randomUUID().toString();
+    commitTs =
+        client.writeAtLeastOnce(
+            Arrays.asList(
+                Mutation.newInsertOrUpdateBuilder("CHANGE_SETS")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .set("COMMIT_TIMESTAMP")
+                    .to(Value.COMMIT_TIMESTAMP)
+                    .build(),
+                Mutation.newUpdateBuilder("NUMBERS")
+                    .set("ID")
+                    .to(1L)
+                    .set("NAME")
+                    .to("one")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build(),
+                Mutation.newUpdateBuilder("NUMBERS")
+                    .set("ID")
+                    .to(5L)
+                    .set("NAME")
+                    .to("five")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build()));
+
+    List<Struct> updates = drainChanges();
+    assertThat(updates).hasSize(2);
+    assertThat(updates)
+        .containsExactly(
+            Struct.newBuilder()
+                .set("ID")
+                .to(1L)
+                .set("NAME")
+                .to("one")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build(),
+            Struct.newBuilder()
+                .set("ID")
+                .to(5L)
+                .set("NAME")
+                .to("five")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build());
+    assertThat(lastCommitTimestamp).isEqualTo(commitTs);
+
+    // Verify that deletes are not picked up by the poller.
+    commitTs =
+        client.writeAtLeastOnce(
+            Arrays.asList(
+                Mutation.delete("NUMBERS", Key.of(2L)), Mutation.delete("NUMBERS", Key.of(3L))));
+    Thread.sleep(500L);
+    assertThat(receivedChanges).isEmpty();
+    poller.stopAsync().awaitTerminated();
+  }
+
+  @Test
+  public void testSpannerChangeSetPollerUsingChangeSetDatabaseClient() throws Exception {
+    Spanner spanner = env.getSpanner();
+    SpannerTableChangeSetPoller poller =
+        SpannerTableChangeSetPoller.newBuilder(spanner, TableId.of(database.getId(), "NUMBERS"))
+            .setPollInterval(Duration.ofMillis(10L))
+            .setCommitTimestampRepository(
+                SpannerCommitTimestampRepository.newBuilder(spanner, database.getId())
+                    .setInitialCommitTimestamp(Timestamp.MIN_VALUE)
+                    .build())
+            .build();
+    poller.addCallback(
+        new RowChangeCallback() {
+          @Override
+          public void rowChange(TableId table, Row row, Timestamp commitTimestamp) {
+            logger.info(
+                String.format(
+                    "Received changed for table %s: %s", table, row.asStruct().toString()));
+            receivedChanges.add(row.asStruct());
+            lastCommitTimestamp = commitTimestamp;
+            latch.countDown();
+          }
+        });
+    poller.startAsync().awaitRunning();
+
+    DatabaseClientWithChangeSets client =
+        DatabaseClientWithChangeSets.of(spanner.getDatabaseClient(database.getId()));
+    latch = new CountDownLatch(3);
+    String changeSetId = client.newChangeSetId();
+    Timestamp commitTs =
+        client.writeAtLeastOnce(
+            changeSetId,
+            Arrays.asList(
+                Mutation.newInsertOrUpdateBuilder("NUMBERS")
+                    .set("ID")
+                    .to(1L)
+                    .set("NAME")
+                    .to("ONE")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build(),
+                Mutation.newInsertOrUpdateBuilder("NUMBERS")
+                    .set("ID")
+                    .to(2L)
+                    .set("NAME")
+                    .to("TWO")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build(),
+                Mutation.newInsertOrUpdateBuilder("NUMBERS")
+                    .set("ID")
+                    .to(3L)
+                    .set("NAME")
+                    .to("THREE")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build()));
+
+    List<Struct> inserts = drainChanges();
+    assertThat(inserts).hasSize(3);
+    assertThat(inserts)
+        .containsExactly(
+            Struct.newBuilder()
+                .set("ID")
+                .to(1L)
+                .set("NAME")
+                .to("ONE")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build(),
+            Struct.newBuilder()
+                .set("ID")
+                .to(2L)
+                .set("NAME")
+                .to("TWO")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build(),
+            Struct.newBuilder()
+                .set("ID")
+                .to(3L)
+                .set("NAME")
+                .to("THREE")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build());
+    assertThat(lastCommitTimestamp).isEqualTo(commitTs);
+
+    latch = new CountDownLatch(2);
+    changeSetId = client.newChangeSetId();
+    commitTs =
+        client.writeAtLeastOnce(
+            changeSetId,
+            Arrays.asList(
+                Mutation.newInsertOrUpdateBuilder("NUMBERS")
+                    .set("ID")
+                    .to(4L)
+                    .set("NAME")
+                    .to("FOUR")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build(),
+                Mutation.newInsertOrUpdateBuilder("NUMBERS")
+                    .set("ID")
+                    .to(5L)
+                    .set("NAME")
+                    .to("FIVE")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build()));
+
+    inserts = drainChanges();
+    assertThat(inserts).hasSize(2);
+    assertThat(inserts)
+        .containsExactly(
+            Struct.newBuilder()
+                .set("ID")
+                .to(4L)
+                .set("NAME")
+                .to("FOUR")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build(),
+            Struct.newBuilder()
+                .set("ID")
+                .to(5L)
+                .set("NAME")
+                .to("FIVE")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build());
+    assertThat(lastCommitTimestamp).isEqualTo(commitTs);
+
+    latch = new CountDownLatch(2);
+    changeSetId = client.newChangeSetId();
+    commitTs =
+        client.writeAtLeastOnce(
+            changeSetId,
+            Arrays.asList(
+                Mutation.newUpdateBuilder("NUMBERS")
+                    .set("ID")
+                    .to(1L)
+                    .set("NAME")
+                    .to("one")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build(),
+                Mutation.newUpdateBuilder("NUMBERS")
+                    .set("ID")
+                    .to(5L)
+                    .set("NAME")
+                    .to("five")
+                    .set("CHANGE_SET_ID")
+                    .to(changeSetId)
+                    .build()));
+
+    List<Struct> updates = drainChanges();
+    assertThat(updates).hasSize(2);
+    assertThat(updates)
+        .containsExactly(
+            Struct.newBuilder()
+                .set("ID")
+                .to(1L)
+                .set("NAME")
+                .to("one")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build(),
+            Struct.newBuilder()
+                .set("ID")
+                .to(5L)
+                .set("NAME")
+                .to("five")
+                .set("CHANGE_SET_ID")
+                .to(changeSetId)
+                .build());
+    assertThat(lastCommitTimestamp).isEqualTo(commitTs);
+
+    // Write mutations using a read/write transaction.
+    testMutationsWithTransactionRunner(client);
+    // Write changes using DML.
+    testDmlWithTransactionRunner(client);
+
+    // Write mutations using a transaction manager.
+    testMutationsWithTransactionManager(client);
+    // Write changes using DML through a transaction manager.
+    testDmlWithTransactionManager(client);
+
+    // Write mutations using an async read/write transaction runner.
+    testMutationsWithAsyncRunner(client);
+    // Write changes using async DML.
+    testDmlWithAsyncRunner(client);
+
+    // Write mutations using an async transaction manager.
+    testMutationsWithAsyncTransactionManager(client);
+    // Write changes using DML through an async transaction manager.
+    testDmlWithAsyncTransactionManager(client);
+
+    // Verify that deletes are not picked up by the poller.
+    commitTs = client.writeAtLeastOnce(Arrays.asList(Mutation.delete("NUMBERS", Key.of(2L))));
+    Thread.sleep(500L);
+    assertThat(receivedChanges).isEmpty();
+
+    poller.stopAsync().awaitTerminated();
+  }
+
+  private void testMutationsWithTransactionRunner(DatabaseClientWithChangeSets client)
+      throws Exception {
+    latch = new CountDownLatch(2);
+    TransactionRunnerWithChangeSet runner = client.readWriteTransaction();
+    runner.run(
+        new TransactionCallable<Void>() {
+          @Override
+          public Void run(TransactionContext transaction) throws Exception {
+            transaction.buffer(
+                Arrays.asList(
+                    Mutation.newUpdateBuilder("NUMBERS")
+                        .set("ID")
+                        .to(1L)
+                        .set("NAME")
+                        .to("En")
+                        .set("CHANGE_SET_ID")
+                        .to(runner.getChangeSetId())
+                        .build(),
+                    Mutation.newUpdateBuilder("NUMBERS")
+                        .set("ID")
+                        .to(5L)
+                        .set("NAME")
+                        .to("Fem")
+                        .set("CHANGE_SET_ID")
+                        .to(runner.getChangeSetId())
+                        .build()));
+            return null;
+          }
+        });
+    Timestamp commitTs = runner.getCommitTimestamp();
+
+    List<Struct> updates = drainChanges();
+    assertThat(updates).hasSize(2);
+    assertThat(updates)
+        .containsExactly(
+            Struct.newBuilder()
+                .set("ID")
+                .to(1L)
+                .set("NAME")
+                .to("En")
+                .set("CHANGE_SET_ID")
+                .to(runner.getChangeSetId())
+                .build(),
+            Struct.newBuilder()
+                .set("ID")
+                .to(5L)
+                .set("NAME")
+                .to("Fem")
+                .set("CHANGE_SET_ID")
+                .to(runner.getChangeSetId())
+                .build());
+    assertThat(lastCommitTimestamp).isEqualTo(commitTs);
+  }
+
+  private void testDmlWithTransactionRunner(DatabaseClientWithChangeSets client) throws Exception {
+    latch = new CountDownLatch(2);
+    TransactionRunnerWithChangeSet runner = client.readWriteTransaction();
+    runner.run(
+        new TransactionCallable<Void>() {
+          @Override
+          public Void run(TransactionContext transaction) throws Exception {
+            String sql = "UPDATE NUMBERS SET NAME=@name, CHANGE_SET_ID=@changeSet WHERE ID=@id";
+            transaction.batchUpdate(
+                Arrays.asList(
+                    Statement.newBuilder(sql)
+                        .bind("name")
+                        .to("Tre")
+                        .bind("id")
+                        .to(3L)
+                        .bind("changeSet")
+                        .to(runner.getChangeSetId())
+                        .build(),
+                    Statement.newBuilder(sql)
+                        .bind("name")
+                        .to("Fire")
+                        .bind("id")
+                        .to(4L)
+                        .bind("changeSet")
+                        .to(runner.getChangeSetId())
+                        .build()));
+            return null;
+          }
+        });
+    Timestamp commitTs = runner.getCommitTimestamp();
+
+    List<Struct> updates = drainChanges();
+    assertThat(updates).hasSize(2);
+    assertThat(updates)
+        .containsExactly(
+            Struct.newBuilder()
+                .set("ID")
+                .to(3L)
+                .set("NAME")
+                .to("Tre")
+                .set("CHANGE_SET_ID")
+                .to(runner.getChangeSetId())
+                .build(),
+            Struct.newBuilder()
+                .set("ID")
+                .to(4L)
+                .set("NAME")
+                .to("Fire")
+                .set("CHANGE_SET_ID")
+                .to(runner.getChangeSetId())
+                .build());
+    assertThat(lastCommitTimestamp).isEqualTo(commitTs);
+  }
+
+  @SuppressWarnings("resource")
+  private void testMutationsWithTransactionManager(DatabaseClientWithChangeSets client)
+      throws Exception {
+    latch = new CountDownLatch(2);
+    try (TransactionManagerWithChangeSet manager = client.transactionManager()) {
+      TransactionContext txn = manager.begin();
+      while (true) {
+        try {
+          txn.buffer(
+              Arrays.asList(
+                  Mutation.newUpdateBuilder("NUMBERS")
+                      .set("ID")
+                      .to(1L)
+                      .set("NAME")
+                      .to("Uno")
+                      .set("CHANGE_SET_ID")
+                      .to(manager.getChangeSetId())
+                      .build(),
+                  Mutation.newUpdateBuilder("NUMBERS")
+                      .set("ID")
+                      .to(5L)
+                      .set("NAME")
+                      .to("Cinque")
+                      .set("CHANGE_SET_ID")
+                      .to(manager.getChangeSetId())
+                      .build()));
+          manager.commit();
+          break;
+        } catch (AbortedException e) {
+          Thread.sleep(e.getRetryDelayInMillis() / 1000);
+          txn = manager.resetForRetry();
+        }
+      }
+      Timestamp commitTs = manager.getCommitTimestamp();
+
+      List<Struct> updates = drainChanges();
+      assertThat(updates).hasSize(2);
+      assertThat(updates)
+          .containsExactly(
+              Struct.newBuilder()
+                  .set("ID")
+                  .to(1L)
+                  .set("NAME")
+                  .to("Uno")
+                  .set("CHANGE_SET_ID")
+                  .to(manager.getChangeSetId())
+                  .build(),
+              Struct.newBuilder()
+                  .set("ID")
+                  .to(5L)
+                  .set("NAME")
+                  .to("Cinque")
+                  .set("CHANGE_SET_ID")
+                  .to(manager.getChangeSetId())
+                  .build());
+      assertThat(lastCommitTimestamp).isEqualTo(commitTs);
+    }
+  }
+
+  @SuppressWarnings("resource")
+  private void testDmlWithTransactionManager(DatabaseClientWithChangeSets client) throws Exception {
+    latch = new CountDownLatch(2);
+    try (TransactionManagerWithChangeSet manager = client.transactionManager()) {
+      TransactionContext txn = manager.begin();
+      while (true) {
+        try {
+          String sql = "UPDATE NUMBERS SET NAME=@name, CHANGE_SET_ID=@changeSet WHERE ID=@id";
+          txn.batchUpdate(
+              Arrays.asList(
+                  Statement.newBuilder(sql)
+                      .bind("name")
+                      .to("Tres")
+                      .bind("id")
+                      .to(3L)
+                      .bind("changeSet")
+                      .to(manager.getChangeSetId())
+                      .build(),
+                  Statement.newBuilder(sql)
+                      .bind("name")
+                      .to("Cuatro")
+                      .bind("id")
+                      .to(4L)
+                      .bind("changeSet")
+                      .to(manager.getChangeSetId())
+                      .build()));
+          manager.commit();
+          break;
+        } catch (AbortedException e) {
+          Thread.sleep(e.getRetryDelayInMillis() / 1000);
+          txn = manager.resetForRetry();
+        }
+      }
+      Timestamp commitTs = manager.getCommitTimestamp();
+
+      List<Struct> updates = drainChanges();
+      assertThat(updates).hasSize(2);
+      assertThat(updates)
+          .containsExactly(
+              Struct.newBuilder()
+                  .set("ID")
+                  .to(3L)
+                  .set("NAME")
+                  .to("Tres")
+                  .set("CHANGE_SET_ID")
+                  .to(manager.getChangeSetId())
+                  .build(),
+              Struct.newBuilder()
+                  .set("ID")
+                  .to(4L)
+                  .set("NAME")
+                  .to("Cuatro")
+                  .set("CHANGE_SET_ID")
+                  .to(manager.getChangeSetId())
+                  .build());
+      assertThat(lastCommitTimestamp).isEqualTo(commitTs);
+    }
+  }
+
+  private void testMutationsWithAsyncRunner(DatabaseClientWithChangeSets client) throws Exception {
+    latch = new CountDownLatch(2);
+    ExecutorService exec = Executors.newSingleThreadExecutor();
+    AsyncRunnerWithChangeSet runner = client.runAsync();
+    runner.runAsync(
+        new AsyncWork<Void>() {
+          @Override
+          public ApiFuture<Void> doWorkAsync(TransactionContext txn) {
+            txn.buffer(
+                Arrays.asList(
+                    Mutation.newUpdateBuilder("NUMBERS")
+                        .set("ID")
+                        .to(1L)
+                        .set("NAME")
+                        .to("En")
+                        .set("CHANGE_SET_ID")
+                        .to(runner.getChangeSetId())
+                        .build(),
+                    Mutation.newUpdateBuilder("NUMBERS")
+                        .set("ID")
+                        .to(5L)
+                        .set("NAME")
+                        .to("Fem")
+                        .set("CHANGE_SET_ID")
+                        .to(runner.getChangeSetId())
+                        .build()));
+            return ApiFutures.immediateFuture(null);
+          }
+        },
+        exec);
+    ApiFuture<Timestamp> commitTs = runner.getCommitTimestamp();
+
+    List<Struct> updates = drainChanges();
+    assertThat(updates).hasSize(2);
+    assertThat(updates)
+        .containsExactly(
+            Struct.newBuilder()
+                .set("ID")
+                .to(1L)
+                .set("NAME")
+                .to("En")
+                .set("CHANGE_SET_ID")
+                .to(runner.getChangeSetId())
+                .build(),
+            Struct.newBuilder()
+                .set("ID")
+                .to(5L)
+                .set("NAME")
+                .to("Fem")
+                .set("CHANGE_SET_ID")
+                .to(runner.getChangeSetId())
+                .build());
+    assertThat(lastCommitTimestamp).isEqualTo(commitTs.get());
+    exec.shutdown();
+  }
+
+  private void testDmlWithAsyncRunner(DatabaseClientWithChangeSets client) throws Exception {
+    latch = new CountDownLatch(2);
+    ExecutorService exec = Executors.newSingleThreadExecutor();
+    AsyncRunnerWithChangeSet runner = client.runAsync();
+    runner.runAsync(
+        new AsyncWork<Void>() {
+          @Override
+          public ApiFuture<Void> doWorkAsync(TransactionContext txn) {
+            String sql = "UPDATE NUMBERS SET NAME=@name, CHANGE_SET_ID=@changeSet WHERE ID=@id";
+            txn.batchUpdateAsync(
+                Arrays.asList(
+                    Statement.newBuilder(sql)
+                        .bind("name")
+                        .to("Tre")
+                        .bind("id")
+                        .to(3L)
+                        .bind("changeSet")
+                        .to(runner.getChangeSetId())
+                        .build(),
+                    Statement.newBuilder(sql)
+                        .bind("name")
+                        .to("Fire")
+                        .bind("id")
+                        .to(4L)
+                        .bind("changeSet")
+                        .to(runner.getChangeSetId())
+                        .build()));
+            return ApiFutures.immediateFuture(null);
+          }
+        },
+        exec);
+    ApiFuture<Timestamp> commitTs = runner.getCommitTimestamp();
+
+    List<Struct> updates = drainChanges();
+    assertThat(updates).hasSize(2);
+    assertThat(updates)
+        .containsExactly(
+            Struct.newBuilder()
+                .set("ID")
+                .to(3L)
+                .set("NAME")
+                .to("Tre")
+                .set("CHANGE_SET_ID")
+                .to(runner.getChangeSetId())
+                .build(),
+            Struct.newBuilder()
+                .set("ID")
+                .to(4L)
+                .set("NAME")
+                .to("Fire")
+                .set("CHANGE_SET_ID")
+                .to(runner.getChangeSetId())
+                .build());
+    assertThat(lastCommitTimestamp).isEqualTo(commitTs.get());
+    exec.shutdown();
+  }
+
+  private void testMutationsWithAsyncTransactionManager(DatabaseClientWithChangeSets client)
+      throws Exception {
+    latch = new CountDownLatch(2);
+    try (AsyncTransactionManagerWithChangeSet manager = client.transactionManagerAsync()) {
+      Timestamp commitTs;
+      TransactionContextFuture txn = manager.beginAsync();
+      while (true) {
+        try {
+          commitTs =
+              txn.then(
+                      (context, v) -> {
+                        context.buffer(
+                            Arrays.asList(
+                                Mutation.newUpdateBuilder("NUMBERS")
+                                    .set("ID")
+                                    .to(1L)
+                                    .set("NAME")
+                                    .to("Uno")
+                                    .set("CHANGE_SET_ID")
+                                    .to(manager.getChangeSetId())
+                                    .build(),
+                                Mutation.newUpdateBuilder("NUMBERS")
+                                    .set("ID")
+                                    .to(5L)
+                                    .set("NAME")
+                                    .to("Cinque")
+                                    .set("CHANGE_SET_ID")
+                                    .to(manager.getChangeSetId())
+                                    .build()));
+                        return ApiFutures.immediateFuture(null);
+                      },
+                      MoreExecutors.directExecutor())
+                  .commitAsync()
+                  .get();
+          break;
+        } catch (AbortedException e) {
+          Thread.sleep(e.getRetryDelayInMillis() / 1000);
+          txn = manager.resetForRetryAsync();
+        }
+      }
+
+      List<Struct> updates = drainChanges();
+      assertThat(updates).hasSize(2);
+      assertThat(updates)
+          .containsExactly(
+              Struct.newBuilder()
+                  .set("ID")
+                  .to(1L)
+                  .set("NAME")
+                  .to("Uno")
+                  .set("CHANGE_SET_ID")
+                  .to(manager.getChangeSetId())
+                  .build(),
+              Struct.newBuilder()
+                  .set("ID")
+                  .to(5L)
+                  .set("NAME")
+                  .to("Cinque")
+                  .set("CHANGE_SET_ID")
+                  .to(manager.getChangeSetId())
+                  .build());
+      assertThat(lastCommitTimestamp).isEqualTo(commitTs);
+    }
+  }
+
+  private void testDmlWithAsyncTransactionManager(DatabaseClientWithChangeSets client)
+      throws Exception {
+    latch = new CountDownLatch(2);
+    try (AsyncTransactionManagerWithChangeSet manager = client.transactionManagerAsync()) {
+      TransactionContextFuture txn = manager.beginAsync();
+      Timestamp commitTs;
+      while (true) {
+        try {
+          String sql = "UPDATE NUMBERS SET NAME=@name, CHANGE_SET_ID=@changeSet WHERE ID=@id";
+          commitTs =
+              txn.then(
+                      (context, v) ->
+                          context.batchUpdateAsync(
+                              Arrays.asList(
+                                  Statement.newBuilder(sql)
+                                      .bind("name")
+                                      .to("Tres")
+                                      .bind("id")
+                                      .to(3L)
+                                      .bind("changeSet")
+                                      .to(manager.getChangeSetId())
+                                      .build(),
+                                  Statement.newBuilder(sql)
+                                      .bind("name")
+                                      .to("Cuatro")
+                                      .bind("id")
+                                      .to(4L)
+                                      .bind("changeSet")
+                                      .to(manager.getChangeSetId())
+                                      .build())),
+                      MoreExecutors.directExecutor())
+                  .commitAsync()
+                  .get();
+          break;
+        } catch (AbortedException e) {
+          Thread.sleep(e.getRetryDelayInMillis() / 1000);
+          txn = manager.resetForRetryAsync();
+        }
+      }
+
+      List<Struct> updates = drainChanges();
+      assertThat(updates).hasSize(2);
+      assertThat(updates)
+          .containsExactly(
+              Struct.newBuilder()
+                  .set("ID")
+                  .to(3L)
+                  .set("NAME")
+                  .to("Tres")
+                  .set("CHANGE_SET_ID")
+                  .to(manager.getChangeSetId())
+                  .build(),
+              Struct.newBuilder()
+                  .set("ID")
+                  .to(4L)
+                  .set("NAME")
+                  .to("Cuatro")
+                  .set("CHANGE_SET_ID")
+                  .to(manager.getChangeSetId())
+                  .build());
+      assertThat(lastCommitTimestamp).isEqualTo(commitTs);
+    }
+  }
+
+  private ImmutableList<Struct> drainChanges() throws Exception {
+    assertThat(latch.await(10L, TimeUnit.SECONDS)).isTrue();
+    ImmutableList<Struct> changes = ImmutableList.copyOf(receivedChanges);
+    receivedChanges.clear();
+    return changes;
+  }
+}

--- a/samples/spanner-change-watcher-samples/src/main/java/com/google/cloud/spanner/watcher/sample/Samples.java
+++ b/samples/spanner-change-watcher-samples/src/main/java/com/google/cloud/spanner/watcher/sample/Samples.java
@@ -593,8 +593,11 @@ public class Samples {
     SpannerDatabaseChangeWatcher watcher =
         SpannerDatabaseTailer.newBuilder(spanner, databaseId)
             .allTables()
-            // Use the commit timestamp column `LAST_MODIFIED` for all tables.
-            .setCommitTimestampColumnFunction((tableId) -> "LAST_MODIFIED")
+            // Use the commit timestamp column `LAST_MODIFIED` for all data tables and
+            // `COMMIT_TIMESTAMP` for the CHANGE_SETS table.
+            .setCommitTimestampColumnFunction(
+                (tableId) ->
+                    tableId.getTable().equals("CHANGE_SETS") ? "COMMIT_TIMESTAMP" : "LAST_MODIFIED")
             .build();
     watcher.addCallback(
         new RowChangeCallback() {


### PR DESCRIPTION
Having a commit timestamp column directly in a data table that is updated during each transaction can be a breaking change for some applications, as a commit timestamp column that is updated using the PENDING_COMMIT_TIMESTAMP()
function will cause the owning table to no longer be readable during the remainder of the transaction. In addition to this limitation, it is also hard to efficiently index a commit timestamp column, which again can make polling a data table for changes inefficient.

This change allows users to create a change set table that keeps track of the change sets (transactions) that have been executed. Each table that is to be watched for changes reference these change sets through an id column.
This id column can easily be indexed, as it does not contain a monotonically increase value. The change watcher polls the change set table for changes. When a change set is detected, the actual data table is queried for the changes
linked with the specific change set.

Example:

```sql
CREATE TABLE CHANGE_SETS (
   CHANGE_SET_ID STRING(MAX),
   COMMIT_TIMESTAMP TIMESTAMP OPTIONS (allow_commit_timestamp=true)
) PRIMARY KEY (CHANGE_SET_ID);

CREATE TABLE NUMBERS (
   ID INT64 NOT NULL,
   NAME STRING(100),
   CHANGE_SET_ID STRING(MAX)
) PRIMARY KEY (ID);

CREATE INDEX IDX_NUMBERS_CHANGE_SET ON NUMBERS (CHANGE_SET_ID);
```

Every read/write transaction starts by buffering a simple `InsertOrUpdate` mutation with a random change set id for the change sets table:

```java
String changeSetId = UUID.randomUUID().toString();
Mutation.newInsertOrUpdateBuilder("CHANGE_SETS")
    .set("CHANGE_SET_ID")
    .to(changeSetId)
    .set("COMMIT_TIMESTAMP")
    .to(Value.COMMIT_TIMESTAMP)
    .build();
```

All subsequent mutations and DML statements in the same transaction also set the same change set id:

```java
Mutation.newInsertOrUpdateBuilder("NUMBERS")
    .set("ID")
    .to(1L)
    .set("NAME")
    .to("ONE")
    .set("CHANGE_SET_ID")
    .to(changeSetId)
    .build();

String sql = "UPDATE NUMBERS SET NAME=@name, CHANGE_SET_ID=@changeSet WHERE ID=@id";
Statement.newBuilder(sql)
    .bind("name")
    .to("THREE")
    .bind("id")
    .to(3L)
    .bind("changeSet")
    .to(changeSetId)
    .build(),
```

A spanner-change-watcher is watching the `CHANGE_SETS` table for changes by polling for more recent commit timestamps. When it finds one, it subsequently queries the corresponding data table for all rows that were updated using the change set id of the newest row in `CHANGE_SETS`.

```sql
-- Pseudo code for polling for changes

-- Poll CHANGE_SETS for new rows
CHANGES_CURSOR = 
   SELECT CHANGE_SET_ID, COMMIT_TIMESTAMP
   FROM CHANGE_SETS
   WHERE COMMIT_TIMESTAMP > @prevCommitTimestamp
   ORDER BY COMMIT_TIMESTAMP;

-- Read the actual data changes for each new change set id that is found.
-- A rowChanged event is emitted for each row in the NUMBERS table that has been updated in one of the new change sets.
FOR @changeSetId IN CHANGES_CURSOR {
   UPDATED_ROWS_CURSOR =
      SELECT *
      FROM NUMBERS
      WHERE CHANGE_SET_ID=@changeSetId;

   FOR @row IN UPDATED_ROWS_CURSOR {
      emitRowChanged(row, commit_timestamp);
   }
}
```

Fixes #52
