### PR TITLE
feat: add support for NUMERIC data type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,19 @@ jobs:
         command: find . -name 'pom.xml' | sort | xargs cat > /tmp/maven_cache_seed
     - restore_cache:
         key: maven-{{ checksum "/tmp/maven_cache_seed" }}
+    - attach_workspace:
+        at: ~/java-spanner
+    - run:
+        name: Clone and install java-spanner repository
+        command: |
+          echo Cloning java-spanner
+          git clone git@github.com:googleapis/java-spanner.git ~/java-spanner
+          echo Switching to java-spanner workspace
+          cd ~/java-spanner
+          echo Checking out java-spanner https://github.com/googleapis/java-spanner/pull/425
+          git checkout 4f42b9746a2a73953862176d80302bf6eaa57902
+          echo Installing snapshot version of java-spanner
+          mvn -DskipTests clean install
     - run:
         name: Install Dependencies
         command: mvn -DskipTests clean install dependency:resolve-plugins dependency:go-offline --settings 'pom.xml'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,19 +15,6 @@ jobs:
         command: find . -name 'pom.xml' | sort | xargs cat > /tmp/maven_cache_seed
     - restore_cache:
         key: maven-{{ checksum "/tmp/maven_cache_seed" }}
-    - attach_workspace:
-        at: ~/java-spanner
-    - run:
-        name: Clone and install java-spanner repository
-        command: |
-          echo Cloning java-spanner
-          git clone git@github.com:googleapis/java-spanner.git ~/java-spanner
-          echo Switching to java-spanner workspace
-          cd ~/java-spanner
-          echo Checking out java-spanner https://github.com/googleapis/java-spanner/pull/425
-          git checkout 4f42b9746a2a73953862176d80302bf6eaa57902
-          echo Installing snapshot version of java-spanner
-          mvn -DskipTests clean install
     - run:
         name: Install Dependencies
         command: mvn -DskipTests clean install dependency:resolve-plugins dependency:go-offline --settings 'pom.xml'

--- a/google-cloud-spanner-change-archiver/pom.xml
+++ b/google-cloud-spanner-change-archiver/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloudspannerecosystem</groupId>
     <artifactId>spanner-change-watcher</artifactId>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
   </parent>
   
   <properties>
@@ -81,14 +81,14 @@
     <dependency>
       <groupId>com.google.cloudspannerecosystem</groupId>
       <artifactId>google-cloud-spanner-change-watcher</artifactId>
-      <version>0.2.0</version>
+      <version>0.3.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.cloudspannerecosystem</groupId>
       <artifactId>google-cloud-spanner-change-publisher</artifactId>
-      <version>0.2.0</version>
+      <version>0.3.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/google-cloud-spanner-change-publisher/pom.xml
+++ b/google-cloud-spanner-change-publisher/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>com.google.cloudspannerecosystem</groupId>
     <artifactId>spanner-change-watcher</artifactId>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
   </parent>
 
   <dependencies>
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.google.cloudspannerecosystem</groupId>
       <artifactId>google-cloud-spanner-change-watcher</artifactId>
-      <version>0.2.0</version>
+      <version>0.3.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/google-cloud-spanner-change-publisher/src/main/java/com/google/cloud/spanner/publisher/SpannerToAvroFactory.java
+++ b/google-cloud-spanner-change-publisher/src/main/java/com/google/cloud/spanner/publisher/SpannerToAvroFactory.java
@@ -367,6 +367,39 @@ public class SpannerToAvroFactory implements ConverterFactory {
                       .noDefault();
                 }
                 break;
+              case "NUMERIC":
+                // Numeric handled as String type
+                logger.log(Level.FINE, "Made ARRAY<NUMERIC>");
+                if (nullable) {
+                  avroSchemaBuilder
+                      .name(name)
+                      .type()
+                      .unionOf()
+                      .nullType()
+                      .and()
+                      .array()
+                      .items()
+                      .unionOf()
+                      .nullType()
+                      .and()
+                      .stringType()
+                      .endUnion()
+                      .endUnion()
+                      .noDefault();
+                } else {
+                  avroSchemaBuilder
+                      .name(name)
+                      .type()
+                      .array()
+                      .items()
+                      .unionOf()
+                      .nullType()
+                      .and()
+                      .stringType()
+                      .endUnion()
+                      .noDefault();
+                }
+                break;
             }
             break;
           case "BOOL":
@@ -420,6 +453,14 @@ public class SpannerToAvroFactory implements ConverterFactory {
             break;
           case "TIMESTAMP":
             logger.log(Level.FINE, "Made TIMESTAMP");
+            if (nullable) {
+              avroSchemaBuilder.name(name).type().optional().stringType();
+            } else {
+              avroSchemaBuilder.name(name).type().stringType().noDefault();
+            }
+            break;
+          case "NUMERIC":
+            logger.log(Level.FINE, "Made NUMERIC");
             if (nullable) {
               avroSchemaBuilder.name(name).type().optional().stringType();
             } else {
@@ -506,6 +547,10 @@ public class SpannerToAvroFactory implements ConverterFactory {
                   logger.log(Level.FINE, "Put ARRAY<TIMESTAMP>");
                   record.put(x, toStringCollection(row.getTimestampList(x)));
                   break;
+                case "NUMERIC":
+                  logger.log(Level.FINE, "Put ARRAY<NUMERIC>");
+                  record.put(x, toStringCollection(row.getBigDecimalList(x)));
+                  break;
                 default:
                   logger.warning(
                       "Unknown Data type when generating Array Schema: " + arrayTypeString);
@@ -539,6 +584,10 @@ public class SpannerToAvroFactory implements ConverterFactory {
             case "TIMESTAMP":
               logger.log(Level.FINE, "Put TIMESTAMP");
               record.put(x, row.getTimestamp(x).toString());
+              break;
+            case "NUMERIC":
+              logger.log(Level.FINE, "Put NUMERIC");
+              record.put(x, row.getBigDecimal(x).toString());
               break;
             default:
               logger.warning(

--- a/google-cloud-spanner-change-publisher/src/main/java/com/google/cloud/spanner/publisher/SpannerToJsonFactory.java
+++ b/google-cloud-spanner-change-publisher/src/main/java/com/google/cloud/spanner/publisher/SpannerToJsonFactory.java
@@ -76,6 +76,10 @@ public class SpannerToJsonFactory implements ConverterFactory {
                   row.getTimestampList(i).stream()
                       .forEach(t -> arrayObject.add(t == null ? null : t.toString()));
                   break;
+                case NUMERIC:
+                  row.getBigDecimalList(i).stream()
+                      .forEach(t -> arrayObject.add(t == null ? null : t.toString()));
+                  break;
                 case STRUCT:
                 case ARRAY:
                 default:
@@ -109,6 +113,9 @@ public class SpannerToJsonFactory implements ConverterFactory {
               break;
             case TIMESTAMP:
               obj.addProperty(columnName, row.getTimestamp(i).toString());
+              break;
+            case NUMERIC:
+              obj.addProperty(columnName, row.getBigDecimal(i).toString());
               break;
             case STRUCT:
             default:

--- a/google-cloud-spanner-change-publisher/src/test/java/com/google/cloud/spanner/publisher/SpannerToAvroTest.java
+++ b/google-cloud-spanner-change-publisher/src/test/java/com/google/cloud/spanner/publisher/SpannerToAvroTest.java
@@ -38,6 +38,7 @@ import com.google.cloud.spanner.watcher.SpannerUtils;
 import com.google.cloud.spanner.watcher.TableId;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
@@ -176,13 +177,11 @@ public class SpannerToAvroTest {
                 .set("IS_NULLABLE")
                 .to("YES")
                 .build(),
-
-            // ARRAY types.
             Struct.newBuilder()
                 .set("COLUMN_NAME")
                 .to("C15")
                 .set("SPANNER_TYPE")
-                .to("ARRAY<INT64>")
+                .to("NUMERIC")
                 .set("IS_NULLABLE")
                 .to("NO")
                 .build(),
@@ -190,15 +189,17 @@ public class SpannerToAvroTest {
                 .set("COLUMN_NAME")
                 .to("C16")
                 .set("SPANNER_TYPE")
-                .to("ARRAY<INT64>")
+                .to("NUMERIC")
                 .set("IS_NULLABLE")
                 .to("YES")
                 .build(),
+
+            // ARRAY types.
             Struct.newBuilder()
                 .set("COLUMN_NAME")
                 .to("C17")
                 .set("SPANNER_TYPE")
-                .to("ARRAY<BOOL>")
+                .to("ARRAY<INT64>")
                 .set("IS_NULLABLE")
                 .to("NO")
                 .build(),
@@ -206,7 +207,7 @@ public class SpannerToAvroTest {
                 .set("COLUMN_NAME")
                 .to("C18")
                 .set("SPANNER_TYPE")
-                .to("ARRAY<BOOL>")
+                .to("ARRAY<INT64>")
                 .set("IS_NULLABLE")
                 .to("YES")
                 .build(),
@@ -214,7 +215,7 @@ public class SpannerToAvroTest {
                 .set("COLUMN_NAME")
                 .to("C19")
                 .set("SPANNER_TYPE")
-                .to("ARRAY<BYTES(24)>")
+                .to("ARRAY<BOOL>")
                 .set("IS_NULLABLE")
                 .to("NO")
                 .build(),
@@ -222,7 +223,7 @@ public class SpannerToAvroTest {
                 .set("COLUMN_NAME")
                 .to("C20")
                 .set("SPANNER_TYPE")
-                .to("ARRAY<BYTES(MAX)>")
+                .to("ARRAY<BOOL>")
                 .set("IS_NULLABLE")
                 .to("YES")
                 .build(),
@@ -230,7 +231,7 @@ public class SpannerToAvroTest {
                 .set("COLUMN_NAME")
                 .to("C21")
                 .set("SPANNER_TYPE")
-                .to("ARRAY<STRING(100)>")
+                .to("ARRAY<BYTES(24)>")
                 .set("IS_NULLABLE")
                 .to("NO")
                 .build(),
@@ -238,7 +239,7 @@ public class SpannerToAvroTest {
                 .set("COLUMN_NAME")
                 .to("C22")
                 .set("SPANNER_TYPE")
-                .to("ARRAY<STRING(MAX)>")
+                .to("ARRAY<BYTES(MAX)>")
                 .set("IS_NULLABLE")
                 .to("YES")
                 .build(),
@@ -246,7 +247,7 @@ public class SpannerToAvroTest {
                 .set("COLUMN_NAME")
                 .to("C23")
                 .set("SPANNER_TYPE")
-                .to("ARRAY<FLOAT64>")
+                .to("ARRAY<STRING(100)>")
                 .set("IS_NULLABLE")
                 .to("NO")
                 .build(),
@@ -254,7 +255,7 @@ public class SpannerToAvroTest {
                 .set("COLUMN_NAME")
                 .to("C24")
                 .set("SPANNER_TYPE")
-                .to("ARRAY<FLOAT64>")
+                .to("ARRAY<STRING(MAX)>")
                 .set("IS_NULLABLE")
                 .to("YES")
                 .build(),
@@ -262,7 +263,7 @@ public class SpannerToAvroTest {
                 .set("COLUMN_NAME")
                 .to("C25")
                 .set("SPANNER_TYPE")
-                .to("ARRAY<DATE>")
+                .to("ARRAY<FLOAT64>")
                 .set("IS_NULLABLE")
                 .to("NO")
                 .build(),
@@ -270,7 +271,7 @@ public class SpannerToAvroTest {
                 .set("COLUMN_NAME")
                 .to("C26")
                 .set("SPANNER_TYPE")
-                .to("ARRAY<DATE>")
+                .to("ARRAY<FLOAT64>")
                 .set("IS_NULLABLE")
                 .to("YES")
                 .build(),
@@ -278,7 +279,7 @@ public class SpannerToAvroTest {
                 .set("COLUMN_NAME")
                 .to("C27")
                 .set("SPANNER_TYPE")
-                .to("ARRAY<TIMESTAMP>")
+                .to("ARRAY<DATE>")
                 .set("IS_NULLABLE")
                 .to("NO")
                 .build(),
@@ -286,7 +287,39 @@ public class SpannerToAvroTest {
                 .set("COLUMN_NAME")
                 .to("C28")
                 .set("SPANNER_TYPE")
+                .to("ARRAY<DATE>")
+                .set("IS_NULLABLE")
+                .to("YES")
+                .build(),
+            Struct.newBuilder()
+                .set("COLUMN_NAME")
+                .to("C29")
+                .set("SPANNER_TYPE")
                 .to("ARRAY<TIMESTAMP>")
+                .set("IS_NULLABLE")
+                .to("NO")
+                .build(),
+            Struct.newBuilder()
+                .set("COLUMN_NAME")
+                .to("C30")
+                .set("SPANNER_TYPE")
+                .to("ARRAY<TIMESTAMP>")
+                .set("IS_NULLABLE")
+                .to("YES")
+                .build(),
+            Struct.newBuilder()
+                .set("COLUMN_NAME")
+                .to("C31")
+                .set("SPANNER_TYPE")
+                .to("ARRAY<NUMERIC>")
+                .set("IS_NULLABLE")
+                .to("NO")
+                .build(),
+            Struct.newBuilder()
+                .set("COLUMN_NAME")
+                .to("C32")
+                .set("SPANNER_TYPE")
+                .to("ARRAY<NUMERIC>")
                 .set("IS_NULLABLE")
                 .to("YES")
                 .build()));
@@ -331,7 +364,7 @@ public class SpannerToAvroTest {
         .isEqualTo(SchemaBuilder.builder().unionOf().nullType().and().doubleType().endUnion());
     assertThat(schema.getField("C10").schema().isNullable()).isTrue();
 
-    // DATE and TIMESTAMP are both handled as STRING.
+    // DATE, TIMESTAMP and NUMERIC are all handled as STRING.
     assertThat(schema.getField("C11").schema()).isEqualTo(SchemaBuilder.builder().stringType());
     assertThat(schema.getField("C11").schema().isNullable()).isFalse();
     assertThat(schema.getField("C12").schema())
@@ -344,34 +377,13 @@ public class SpannerToAvroTest {
         .isEqualTo(SchemaBuilder.builder().unionOf().nullType().and().stringType().endUnion());
     assertThat(schema.getField("C14").schema().isNullable()).isTrue();
 
-    // ARRAY types.
-    assertThat(schema.getField("C15").schema())
-        .isEqualTo(
-            SchemaBuilder.builder()
-                .array()
-                .items()
-                .unionOf()
-                .nullType()
-                .and()
-                .longType()
-                .endUnion());
+    assertThat(schema.getField("C15").schema()).isEqualTo(SchemaBuilder.builder().stringType());
     assertThat(schema.getField("C15").schema().isNullable()).isFalse();
     assertThat(schema.getField("C16").schema())
-        .isEqualTo(
-            SchemaBuilder.builder()
-                .unionOf()
-                .nullType()
-                .and()
-                .array()
-                .items()
-                .unionOf()
-                .nullType()
-                .and()
-                .longType()
-                .endUnion()
-                .endUnion());
+        .isEqualTo(SchemaBuilder.builder().unionOf().nullType().and().stringType().endUnion());
     assertThat(schema.getField("C16").schema().isNullable()).isTrue();
 
+    // ARRAY types.
     assertThat(schema.getField("C17").schema())
         .isEqualTo(
             SchemaBuilder.builder()
@@ -380,7 +392,7 @@ public class SpannerToAvroTest {
                 .unionOf()
                 .nullType()
                 .and()
-                .booleanType()
+                .longType()
                 .endUnion());
     assertThat(schema.getField("C17").schema().isNullable()).isFalse();
     assertThat(schema.getField("C18").schema())
@@ -394,7 +406,7 @@ public class SpannerToAvroTest {
                 .unionOf()
                 .nullType()
                 .and()
-                .booleanType()
+                .longType()
                 .endUnion()
                 .endUnion());
     assertThat(schema.getField("C18").schema().isNullable()).isTrue();
@@ -407,7 +419,7 @@ public class SpannerToAvroTest {
                 .unionOf()
                 .nullType()
                 .and()
-                .bytesType()
+                .booleanType()
                 .endUnion());
     assertThat(schema.getField("C19").schema().isNullable()).isFalse();
     assertThat(schema.getField("C20").schema())
@@ -421,7 +433,7 @@ public class SpannerToAvroTest {
                 .unionOf()
                 .nullType()
                 .and()
-                .bytesType()
+                .booleanType()
                 .endUnion()
                 .endUnion());
     assertThat(schema.getField("C20").schema().isNullable()).isTrue();
@@ -434,7 +446,7 @@ public class SpannerToAvroTest {
                 .unionOf()
                 .nullType()
                 .and()
-                .stringType()
+                .bytesType()
                 .endUnion());
     assertThat(schema.getField("C21").schema().isNullable()).isFalse();
     assertThat(schema.getField("C22").schema())
@@ -448,7 +460,7 @@ public class SpannerToAvroTest {
                 .unionOf()
                 .nullType()
                 .and()
-                .stringType()
+                .bytesType()
                 .endUnion()
                 .endUnion());
     assertThat(schema.getField("C22").schema().isNullable()).isTrue();
@@ -461,7 +473,7 @@ public class SpannerToAvroTest {
                 .unionOf()
                 .nullType()
                 .and()
-                .doubleType()
+                .stringType()
                 .endUnion());
     assertThat(schema.getField("C23").schema().isNullable()).isFalse();
     assertThat(schema.getField("C24").schema())
@@ -475,12 +487,11 @@ public class SpannerToAvroTest {
                 .unionOf()
                 .nullType()
                 .and()
-                .doubleType()
+                .stringType()
                 .endUnion()
                 .endUnion());
     assertThat(schema.getField("C24").schema().isNullable()).isTrue();
 
-    // DATE and TIMESTAMP are both handled as STRING.
     assertThat(schema.getField("C25").schema())
         .isEqualTo(
             SchemaBuilder.builder()
@@ -489,7 +500,7 @@ public class SpannerToAvroTest {
                 .unionOf()
                 .nullType()
                 .and()
-                .stringType()
+                .doubleType()
                 .endUnion());
     assertThat(schema.getField("C25").schema().isNullable()).isFalse();
     assertThat(schema.getField("C26").schema())
@@ -503,11 +514,12 @@ public class SpannerToAvroTest {
                 .unionOf()
                 .nullType()
                 .and()
-                .stringType()
+                .doubleType()
                 .endUnion()
                 .endUnion());
     assertThat(schema.getField("C26").schema().isNullable()).isTrue();
 
+    // DATE, TIMESTAMP and NUMERIC are all handled as STRING.
     assertThat(schema.getField("C27").schema())
         .isEqualTo(
             SchemaBuilder.builder()
@@ -534,6 +546,60 @@ public class SpannerToAvroTest {
                 .endUnion()
                 .endUnion());
     assertThat(schema.getField("C28").schema().isNullable()).isTrue();
+
+    assertThat(schema.getField("C29").schema())
+        .isEqualTo(
+            SchemaBuilder.builder()
+                .array()
+                .items()
+                .unionOf()
+                .nullType()
+                .and()
+                .stringType()
+                .endUnion());
+    assertThat(schema.getField("C29").schema().isNullable()).isFalse();
+    assertThat(schema.getField("C30").schema())
+        .isEqualTo(
+            SchemaBuilder.builder()
+                .unionOf()
+                .nullType()
+                .and()
+                .array()
+                .items()
+                .unionOf()
+                .nullType()
+                .and()
+                .stringType()
+                .endUnion()
+                .endUnion());
+    assertThat(schema.getField("C30").schema().isNullable()).isTrue();
+
+    assertThat(schema.getField("C31").schema())
+        .isEqualTo(
+            SchemaBuilder.builder()
+                .array()
+                .items()
+                .unionOf()
+                .nullType()
+                .and()
+                .stringType()
+                .endUnion());
+    assertThat(schema.getField("C31").schema().isNullable()).isFalse();
+    assertThat(schema.getField("C32").schema())
+        .isEqualTo(
+            SchemaBuilder.builder()
+                .unionOf()
+                .nullType()
+                .and()
+                .array()
+                .items()
+                .unionOf()
+                .nullType()
+                .and()
+                .stringType()
+                .endUnion()
+                .endUnion());
+    assertThat(schema.getField("C32").schema().isNullable()).isTrue();
   }
 
   @Test
@@ -595,46 +661,55 @@ public class SpannerToAvroTest {
             .to(Timestamp.parseTimestamp("2020-03-31T21:21:15.120Z"))
             .set("C14")
             .to((Timestamp) null)
-            // ARRAY types
             .set("C15")
-            .toInt64Array(Arrays.asList(1L, null, 3L, null, 5L))
+            .to(new BigDecimal("3.14"))
             .set("C16")
-            .toInt64Array((long[]) null)
+            .to((BigDecimal) null)
+            // ARRAY types
             .set("C17")
-            .toBoolArray(Arrays.asList(true, null, false, null))
+            .toInt64Array(Arrays.asList(1L, null, 3L, null, 5L))
             .set("C18")
-            .toBoolArray((boolean[]) null)
+            .toInt64Array((long[]) null)
             .set("C19")
+            .toBoolArray(Arrays.asList(true, null, false, null))
+            .set("C20")
+            .toBoolArray((boolean[]) null)
+            .set("C21")
             .toBytesArray(
                 Arrays.asList(ByteArray.copyFrom("TEST"), null, ByteArray.copyFrom("FOO"), null))
-            .set("C20")
-            .toBytesArray(null)
-            .set("C21")
-            .toStringArray(Arrays.asList("TEST", null, "FOO", null))
             .set("C22")
-            .toStringArray(null)
+            .toBytesArray(null)
             .set("C23")
-            .toFloat64Array(Arrays.asList(3.14D, null, 6.626D, null))
+            .toStringArray(Arrays.asList("TEST", null, "FOO", null))
             .set("C24")
-            .toFloat64Array((double[]) null)
+            .toStringArray(null)
             .set("C25")
+            .toFloat64Array(Arrays.asList(3.14D, null, 6.626D, null))
+            .set("C26")
+            .toFloat64Array((double[]) null)
+            .set("C27")
             .toDateArray(
                 Arrays.asList(
                     Date.fromYearMonthDay(2020, 3, 31),
                     null,
                     Date.fromYearMonthDay(1970, 1, 1),
                     null))
-            .set("C26")
+            .set("C28")
             .toDateArray(null)
-            .set("C27")
+            .set("C29")
             .toTimestampArray(
                 Arrays.asList(
                     Timestamp.parseTimestamp("2020-03-31T21:21:15.120Z"),
                     null,
                     Timestamp.ofTimeSecondsAndNanos(0, 0),
                     null))
-            .set("C28")
+            .set("C30")
             .toTimestampArray(null)
+            .set("C31")
+            .toNumericArray(
+                Arrays.asList(new BigDecimal("3.14"), null, new BigDecimal("6.6260"), null))
+            .set("C32")
+            .toNumericArray(null)
             .build();
 
     ByteString data = converter.convert(row);
@@ -665,32 +740,37 @@ public class SpannerToAvroTest {
     assertThat(record.get("C12")).isNull();
     assertThat(record.get("C13")).isEqualTo(new Utf8("2020-03-31T21:21:15.120000000Z"));
     assertThat(record.get("C14")).isNull();
-    // ARRAY types
-    assertThat(record.get("C15")).isEqualTo(Arrays.asList(1L, null, 3L, null, 5L));
+    assertThat(record.get("C15")).isEqualTo(new Utf8("3.14"));
     assertThat(record.get("C16")).isNull();
-    assertThat(record.get("C17")).isEqualTo(Arrays.asList(true, null, false, null));
+    // ARRAY types
+    assertThat(record.get("C17")).isEqualTo(Arrays.asList(1L, null, 3L, null, 5L));
     assertThat(record.get("C18")).isNull();
-    assertThat(record.get("C19"))
+    assertThat(record.get("C19")).isEqualTo(Arrays.asList(true, null, false, null));
+    assertThat(record.get("C20")).isNull();
+    assertThat(record.get("C21"))
         .isEqualTo(
             Arrays.asList(
                 ByteBuffer.wrap("TEST".getBytes()), null, ByteBuffer.wrap("FOO".getBytes()), null));
-    assertThat(record.get("C20")).isNull();
-    assertThat(record.get("C21"))
-        .isEqualTo(Arrays.asList(new Utf8("TEST"), null, new Utf8("FOO"), null));
     assertThat(record.get("C22")).isNull();
-    assertThat(record.get("C23")).isEqualTo(Arrays.asList(3.14D, null, 6.626D, null));
+    assertThat(record.get("C23"))
+        .isEqualTo(Arrays.asList(new Utf8("TEST"), null, new Utf8("FOO"), null));
     assertThat(record.get("C24")).isNull();
-    assertThat(record.get("C25"))
-        .isEqualTo(Arrays.asList(new Utf8("2020-03-31"), null, new Utf8("1970-01-01"), null));
+    assertThat(record.get("C25")).isEqualTo(Arrays.asList(3.14D, null, 6.626D, null));
     assertThat(record.get("C26")).isNull();
     assertThat(record.get("C27"))
+        .isEqualTo(Arrays.asList(new Utf8("2020-03-31"), null, new Utf8("1970-01-01"), null));
+    assertThat(record.get("C28")).isNull();
+    assertThat(record.get("C29"))
         .isEqualTo(
             Arrays.asList(
                 new Utf8("2020-03-31T21:21:15.120000000Z"),
                 null,
                 new Utf8("1970-01-01T00:00:00Z"),
                 null));
-    assertThat(record.get("C28")).isNull();
+    assertThat(record.get("C30")).isNull();
+    assertThat(record.get("C31"))
+        .isEqualTo(Arrays.asList(new Utf8("3.14"), null, new Utf8("6.6260"), null));
+    assertThat(record.get("C32")).isNull();
   }
 
   private ResultSet createTimestampColumnResultSet() {

--- a/google-cloud-spanner-change-publisher/src/test/java/com/google/cloud/spanner/publisher/SpannerToJsonTest.java
+++ b/google-cloud-spanner-change-publisher/src/test/java/com/google/cloud/spanner/publisher/SpannerToJsonTest.java
@@ -34,6 +34,7 @@ import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -78,46 +79,55 @@ public class SpannerToJsonTest {
             .to(Timestamp.parseTimestamp("2020-03-31T21:21:15.120Z"))
             .set("C14")
             .to((Timestamp) null)
-            // ARRAY types
             .set("C15")
-            .toInt64Array(Arrays.asList(1L, null, 3L, null, 5L))
+            .to(new BigDecimal("3.14"))
             .set("C16")
-            .toInt64Array((long[]) null)
+            .to((BigDecimal) null)
+            // ARRAY types
             .set("C17")
-            .toBoolArray(Arrays.asList(true, null, false, null))
+            .toInt64Array(Arrays.asList(1L, null, 3L, null, 5L))
             .set("C18")
-            .toBoolArray((boolean[]) null)
+            .toInt64Array((long[]) null)
             .set("C19")
+            .toBoolArray(Arrays.asList(true, null, false, null))
+            .set("C20")
+            .toBoolArray((boolean[]) null)
+            .set("C21")
             .toBytesArray(
                 Arrays.asList(ByteArray.copyFrom("TEST"), null, ByteArray.copyFrom("FOO"), null))
-            .set("C20")
-            .toBytesArray(null)
-            .set("C21")
-            .toStringArray(Arrays.asList("TEST", null, "FOO", null))
             .set("C22")
-            .toStringArray(null)
+            .toBytesArray(null)
             .set("C23")
-            .toFloat64Array(Arrays.asList(3.14D, null, 6.626D, null))
+            .toStringArray(Arrays.asList("TEST", null, "FOO", null))
             .set("C24")
-            .toFloat64Array((double[]) null)
+            .toStringArray(null)
             .set("C25")
+            .toFloat64Array(Arrays.asList(3.14D, null, 6.626D, null))
+            .set("C26")
+            .toFloat64Array((double[]) null)
+            .set("C27")
             .toDateArray(
                 Arrays.asList(
                     Date.fromYearMonthDay(2020, 3, 31),
                     null,
                     Date.fromYearMonthDay(1970, 1, 1),
                     null))
-            .set("C26")
+            .set("C28")
             .toDateArray(null)
-            .set("C27")
+            .set("C29")
             .toTimestampArray(
                 Arrays.asList(
                     Timestamp.parseTimestamp("2020-03-31T21:21:15.120Z"),
                     null,
                     Timestamp.ofTimeSecondsAndNanos(0, 0),
                     null))
-            .set("C28")
+            .set("C30")
             .toTimestampArray(null)
+            .set("C31")
+            .toNumericArray(
+                Arrays.asList(new BigDecimal("3.14"), null, new BigDecimal("6.6260"), null))
+            .set("C32")
+            .toNumericArray(null)
             .build();
 
     ByteString data = converter.convert(row);
@@ -141,29 +151,33 @@ public class SpannerToJsonTest {
     assertThat(record.get("C12")).isEqualTo(JsonNull.INSTANCE);
     assertThat(record.get("C13")).isEqualTo(new JsonPrimitive("2020-03-31T21:21:15.120000000Z"));
     assertThat(record.get("C14")).isEqualTo(JsonNull.INSTANCE);
-    // ARRAY types
-    assertThat(record.get("C15")).isEqualTo(toJsonArray(1L, null, 3L, null, 5L));
+    assertThat(record.get("C15")).isEqualTo(new JsonPrimitive("3.14"));
     assertThat(record.get("C16")).isEqualTo(JsonNull.INSTANCE);
-    assertThat(record.get("C17")).isEqualTo(toJsonArray(true, null, false, null));
+    // ARRAY types
+    assertThat(record.get("C17")).isEqualTo(toJsonArray(1L, null, 3L, null, 5L));
     assertThat(record.get("C18")).isEqualTo(JsonNull.INSTANCE);
-    assertThat(record.get("C19"))
+    assertThat(record.get("C19")).isEqualTo(toJsonArray(true, null, false, null));
+    assertThat(record.get("C20")).isEqualTo(JsonNull.INSTANCE);
+    assertThat(record.get("C21"))
         .isEqualTo(
             toJsonArray(
                 ByteArray.copyFrom("TEST").toBase64(),
                 null,
                 ByteArray.copyFrom("FOO").toBase64(),
                 null));
-    assertThat(record.get("C20")).isEqualTo(JsonNull.INSTANCE);
-    assertThat(record.get("C21")).isEqualTo(toJsonArray("TEST", null, "FOO", null));
     assertThat(record.get("C22")).isEqualTo(JsonNull.INSTANCE);
-    assertThat(record.get("C23")).isEqualTo(toJsonArray(3.14D, null, 6.626D, null));
+    assertThat(record.get("C23")).isEqualTo(toJsonArray("TEST", null, "FOO", null));
     assertThat(record.get("C24")).isEqualTo(JsonNull.INSTANCE);
-    assertThat(record.get("C25")).isEqualTo(toJsonArray("2020-03-31", null, "1970-01-01", null));
+    assertThat(record.get("C25")).isEqualTo(toJsonArray(3.14D, null, 6.626D, null));
     assertThat(record.get("C26")).isEqualTo(JsonNull.INSTANCE);
-    assertThat(record.get("C27"))
+    assertThat(record.get("C27")).isEqualTo(toJsonArray("2020-03-31", null, "1970-01-01", null));
+    assertThat(record.get("C28")).isEqualTo(JsonNull.INSTANCE);
+    assertThat(record.get("C29"))
         .isEqualTo(
             toJsonArray("2020-03-31T21:21:15.120000000Z", null, "1970-01-01T00:00:00Z", null));
-    assertThat(record.get("C28")).isEqualTo(JsonNull.INSTANCE);
+    assertThat(record.get("C30")).isEqualTo(JsonNull.INSTANCE);
+    assertThat(record.get("C31")).isEqualTo(toJsonArray("3.14", null, "6.6260", null));
+    assertThat(record.get("C32")).isEqualTo(JsonNull.INSTANCE);
   }
 
   private static JsonArray toJsonArray(Long... values) {

--- a/google-cloud-spanner-change-watcher/pom.xml
+++ b/google-cloud-spanner-change-watcher/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloudspannerecosystem</groupId>
     <artifactId>spanner-change-watcher</artifactId>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
   </parent>
 
   <dependencies>

--- a/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerDatabaseChangeSetPoller.java
+++ b/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerDatabaseChangeSetPoller.java
@@ -283,7 +283,7 @@ public class SpannerDatabaseChangeSetPoller extends AbstractApiService
   private final Duration pollInterval;
   private final ScheduledExecutorService executor;
   private final boolean isOwnedExecutor;
-  private ImmutableList<TableId> tables;
+  private List<TableId> tables;
   private Map<TableId, SpannerTableChangeWatcher> watchers;
   private final List<RowChangeCallback> callbacks = new LinkedList<>();
 
@@ -313,7 +313,7 @@ public class SpannerDatabaseChangeSetPoller extends AbstractApiService
     }
   }
 
-  private ImmutableList<TableId> findTableNames(DatabaseClient client) {
+  private List<TableId> findTableNames(DatabaseClient client) {
     Statement statement =
         Statement.newBuilder(LIST_TABLE_NAMES_STATEMENT)
             .bind("excluded")
@@ -329,7 +329,7 @@ public class SpannerDatabaseChangeSetPoller extends AbstractApiService
             .bind("changeSetIdColumn")
             .to(dataTableChangeSetIdColumn)
             .build();
-    ImmutableList<TableId> tables =
+    List<TableId> tables =
         client
             .singleUse()
             .executeQueryAsync(statement)
@@ -375,7 +375,7 @@ public class SpannerDatabaseChangeSetPoller extends AbstractApiService
           @Override
           public void run() {
             try {
-              ImmutableList<TableId> tables = getTables();
+              List<TableId> tables = getTables();
               if (tables.isEmpty()) {
                 throw SpannerExceptionFactory.newSpannerException(
                     ErrorCode.NOT_FOUND,
@@ -418,7 +418,7 @@ public class SpannerDatabaseChangeSetPoller extends AbstractApiService
   }
 
   @Override
-  public ImmutableList<TableId> getTables() {
+  public List<TableId> getTables() {
     synchronized (lock) {
       if (tables == null) {
         tables = findTableNames(spanner.getDatabaseClient(databaseId));

--- a/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerDatabaseTailer.java
+++ b/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerDatabaseTailer.java
@@ -303,7 +303,7 @@ public class SpannerDatabaseTailer extends AbstractApiService
   private final ScheduledExecutorService executor;
   private final boolean isOwnedExecutor;
   private final java.util.function.Function<TableId, String> commitTimestampColumnFunction;
-  private ImmutableList<TableId> tables;
+  private List<TableId> tables;
   private Map<TableId, SpannerTableChangeWatcher> watchers;
   private final List<RowChangeCallback> callbacks = new LinkedList<>();
 
@@ -329,7 +329,7 @@ public class SpannerDatabaseTailer extends AbstractApiService
     this.commitTimestampColumnFunction = builder.commitTimestampColumnFunction;
   }
 
-  private ImmutableList<TableId> findTableNames(DatabaseClient client) {
+  private List<TableId> findTableNames(DatabaseClient client) {
     Statement statement =
         Statement.newBuilder(LIST_TABLE_NAMES_STATEMENT)
             .bind("excluded")
@@ -343,7 +343,7 @@ public class SpannerDatabaseTailer extends AbstractApiService
             .bind("catalog")
             .to(catalog)
             .build();
-    ImmutableList<TableId> tables =
+    List<TableId> tables =
         client
             .singleUse()
             .executeQueryAsync(statement)
@@ -389,7 +389,7 @@ public class SpannerDatabaseTailer extends AbstractApiService
           @Override
           public void run() {
             try {
-              ImmutableList<TableId> tables = getTables();
+              List<TableId> tables = getTables();
               if (tables.isEmpty()) {
                 throw SpannerExceptionFactory.newSpannerException(
                     ErrorCode.NOT_FOUND,
@@ -432,7 +432,7 @@ public class SpannerDatabaseTailer extends AbstractApiService
   }
 
   @Override
-  public ImmutableList<TableId> getTables() {
+  public List<TableId> getTables() {
     synchronized (lock) {
       if (tables == null) {
         tables = findTableNames(spanner.getDatabaseClient(databaseId));

--- a/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerUtils.java
+++ b/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/SpannerUtils.java
@@ -31,8 +31,8 @@ import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.StructReader;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
-import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.MoreExecutors;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
@@ -133,8 +133,7 @@ public class SpannerUtils {
 
   /** Returns the primary key columns of a table. */
   @InternalApi
-  public static ApiFuture<ImmutableList<String>> getPrimaryKeyColumns(
-      DatabaseClient client, TableId table) {
+  public static ApiFuture<List<String>> getPrimaryKeyColumns(DatabaseClient client, TableId table) {
     try (AsyncResultSet rs =
         client
             .singleUse()

--- a/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/RandomResultSetGenerator.java
+++ b/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/RandomResultSetGenerator.java
@@ -48,6 +48,7 @@ public class RandomResultSetGenerator {
         Type.newBuilder().setCode(TypeCode.BYTES).build(),
         Type.newBuilder().setCode(TypeCode.DATE).build(),
         Type.newBuilder().setCode(TypeCode.TIMESTAMP).build(),
+        Type.newBuilder().setCode(TypeCode.NUMERIC).build(),
         Type.newBuilder()
             .setCode(TypeCode.ARRAY)
             .setArrayElementType(Type.newBuilder().setCode(TypeCode.BOOL))
@@ -75,6 +76,10 @@ public class RandomResultSetGenerator {
         Type.newBuilder()
             .setCode(TypeCode.ARRAY)
             .setArrayElementType(Type.newBuilder().setCode(TypeCode.TIMESTAMP))
+            .build(),
+        Type.newBuilder()
+            .setCode(TypeCode.ARRAY)
+            .setArrayElementType(Type.newBuilder().setCode(TypeCode.NUMERIC))
             .build(),
       };
 
@@ -245,6 +250,9 @@ public class RandomResultSetGenerator {
                       .setNanos(random.nextInt(1000_000_000))
                       .build());
           builder.setStringValue(Timestamp.fromProto(ts).toString());
+          break;
+        case NUMERIC:
+          builder.setStringValue(random.nextInt() + "." + random.nextInt(1000000000));
           break;
         case STRUCT:
         case TYPE_CODE_UNSPECIFIED:

--- a/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/it/ITSpannerTableTailerStressTest.java
+++ b/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/it/ITSpannerTableTailerStressTest.java
@@ -46,6 +46,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -470,6 +471,16 @@ public class ITSpannerTableTailerStressTest {
     }
 
     @Override
+    public BigDecimal getBigDecimal(int columnIndex) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BigDecimal getBigDecimal(String columnName) {
+      return values.get(columnName).getNumeric();
+    }
+
+    @Override
     public boolean[] getBooleanArray(int columnIndex) {
       throw new UnsupportedOperationException();
     }
@@ -567,6 +578,16 @@ public class ITSpannerTableTailerStressTest {
     @Override
     public List<Date> getDateList(String columnName) {
       return values.get(columnName).getDateArray();
+    }
+
+    @Override
+    public List<BigDecimal> getBigDecimalList(int columnIndex) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<BigDecimal> getBigDecimalList(String columnName) {
+      return values.get(columnName).getNumericArray();
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloudspannerecosystem</groupId>
   <artifactId>spanner-change-watcher</artifactId>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <name>Google Cloud Spanner Change Watcher Parent</name>
   <description>Google Cloud Spanner Change Watcher and Publisher is a framework that emits events when a row has been changed in a Cloud Spanner database. These row change events can be captured and processed in-process as part of a user application, or they can be published to Google Cloud Pubsub for consumption by any other application.</description>
   <url>https://github.com/cloudspannerecosystem/spanner-change-watcher</url>
@@ -67,7 +67,7 @@
       <dependency>
         <groupId>com.google.cloudspannerecosystem</groupId>
         <artifactId>google-cloud-spanner-change-watcher</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0</version>
         <exclusions>
           <exclusion>
             <groupId>org.conscrypt</groupId>
@@ -78,12 +78,12 @@
       <dependency>
         <groupId>com.google.cloudspannerecosystem</groupId>
         <artifactId>google-cloud-spanner-change-publisher</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.cloudspannerecosystem</groupId>
         <artifactId>google-cloud-spanner-change-archiver</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0</version>
       </dependency>
       
       <dependency>
@@ -91,13 +91,13 @@
         <artifactId>google-cloud-spanner-bom</artifactId>
         <type>pom</type>
         <scope>import</scope>
-        <version>1.58.0</version>
+        <version>1.61.0</version>
       </dependency>
-      
+       
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>8.0.0</version>
+        <version>10.1.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -150,9 +150,6 @@
             <serverId>ossrh</serverId>
             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
             <autoReleaseAfterClose>true</autoReleaseAfterClose>
-            <!-- 
-            <stagingProgressTimeoutMinutes>15</stagingProgressTimeoutMinutes>
-             -->
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <artifactId>google-cloud-spanner-bom</artifactId>
         <type>pom</type>
         <scope>import</scope>
-        <version>1.61.0</version>
+        <version>2.0.1</version>
       </dependency>
        
       <dependency>

--- a/samples/spanner-change-publisher-samples/pom.xml
+++ b/samples/spanner-change-publisher-samples/pom.xml
@@ -5,14 +5,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloudspannerecosystem</groupId>
   <artifactId>spanner-change-publisher-samples</artifactId>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <packaging>jar</packaging>
   <name>Google Cloud Spanner Change Publisher Samples</name>
   <description>Google Cloud Spanner Data Change Publisher Samples</description>
   <parent>
     <groupId>com.google.cloudspannerecosystem</groupId>
     <artifactId>spanner-change-watcher</artifactId>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
     <relativePath>../..</relativePath>
   </parent>
   
@@ -42,14 +42,14 @@
     <dependency>
       <groupId>com.google.cloudspannerecosystem</groupId>
       <artifactId>google-cloud-spanner-change-publisher</artifactId>
-      <version>0.2.0</version>
+      <version>0.3.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.cloudspannerecosystem</groupId>
       <artifactId>google-cloud-spanner-change-watcher</artifactId>
-      <version>0.2.0</version>
+      <version>0.3.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/samples/spanner-change-watcher-samples/pom.xml
+++ b/samples/spanner-change-watcher-samples/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.google.cloudspannerecosystem</groupId>
     <artifactId>spanner-change-watcher</artifactId>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
     <relativePath>../..</relativePath>
   </parent>
   
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>com.google.cloudspannerecosystem</groupId>
       <artifactId>google-cloud-spanner-change-watcher</artifactId>
-      <version>0.2.0</version>
+      <version>0.3.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Adds support for `NUMERIC` to Cloud Spanner Change Watcher.

Fixes #56 