### PR TITLE
deps: bump Spanner version to 3.3.2

### DIFF
--- a/google-cloud-spanner-change-archiver/pom.xml
+++ b/google-cloud-spanner-change-archiver/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloudspannerecosystem</groupId>
     <artifactId>spanner-change-watcher</artifactId>
-    <version>0.4.0</version>
+    <version>1.0.0</version>
   </parent>
   
   <properties>
@@ -81,14 +81,14 @@
     <dependency>
       <groupId>com.google.cloudspannerecosystem</groupId>
       <artifactId>google-cloud-spanner-change-watcher</artifactId>
-      <version>0.4.0</version>
+      <version>1.0.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.cloudspannerecosystem</groupId>
       <artifactId>google-cloud-spanner-change-publisher</artifactId>
-      <version>0.4.0</version>
+      <version>1.0.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/google-cloud-spanner-change-archiver/pom.xml
+++ b/google-cloud-spanner-change-archiver/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloudspannerecosystem</groupId>
     <artifactId>spanner-change-watcher</artifactId>
-    <version>0.3.0</version>
+    <version>0.4.0</version>
   </parent>
   
   <properties>
@@ -81,14 +81,14 @@
     <dependency>
       <groupId>com.google.cloudspannerecosystem</groupId>
       <artifactId>google-cloud-spanner-change-watcher</artifactId>
-      <version>0.3.0</version>
+      <version>0.4.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.cloudspannerecosystem</groupId>
       <artifactId>google-cloud-spanner-change-publisher</artifactId>
-      <version>0.3.0</version>
+      <version>0.4.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
@@ -116,6 +116,7 @@
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
+      <version>${gax.version}</version>
       <classifier>testlib</classifier>
       <scope>test</scope>
     </dependency>

--- a/google-cloud-spanner-change-publisher/pom.xml
+++ b/google-cloud-spanner-change-publisher/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>com.google.cloudspannerecosystem</groupId>
     <artifactId>spanner-change-watcher</artifactId>
-    <version>0.3.0</version>
+    <version>0.4.0</version>
   </parent>
 
   <dependencies>
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.google.cloudspannerecosystem</groupId>
       <artifactId>google-cloud-spanner-change-watcher</artifactId>
-      <version>0.3.0</version>
+      <version>0.4.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
@@ -90,6 +90,7 @@
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
+      <version>${gax.version}</version>
       <classifier>testlib</classifier>
       <scope>test</scope>
     </dependency>

--- a/google-cloud-spanner-change-publisher/pom.xml
+++ b/google-cloud-spanner-change-publisher/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>com.google.cloudspannerecosystem</groupId>
     <artifactId>spanner-change-watcher</artifactId>
-    <version>0.4.0</version>
+    <version>1.0.0</version>
   </parent>
 
   <dependencies>
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.google.cloudspannerecosystem</groupId>
       <artifactId>google-cloud-spanner-change-watcher</artifactId>
-      <version>0.4.0</version>
+      <version>1.0.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/google-cloud-spanner-change-watcher/pom.xml
+++ b/google-cloud-spanner-change-watcher/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloudspannerecosystem</groupId>
     <artifactId>spanner-change-watcher</artifactId>
-    <version>0.4.0</version>
+    <version>1.0.0</version>
   </parent>
 
   <dependencies>

--- a/google-cloud-spanner-change-watcher/pom.xml
+++ b/google-cloud-spanner-change-watcher/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloudspannerecosystem</groupId>
     <artifactId>spanner-change-watcher</artifactId>
-    <version>0.3.0</version>
+    <version>0.4.0</version>
   </parent>
 
   <dependencies>
@@ -49,6 +49,7 @@
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
+      <version>${gax.version}</version>
       <classifier>testlib</classifier>
       <scope>test</scope>
     </dependency>

--- a/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/DatabaseClientWithChangeSets.java
+++ b/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/DatabaseClientWithChangeSets.java
@@ -491,7 +491,7 @@ public class DatabaseClientWithChangeSets implements DatabaseClient {
    */
   @Override
   public TransactionManagerWithChangeSet transactionManager(TransactionOption... options) {
-    return new TransactionManagerWithChangeSetImpl(client.transactionManager());
+    return new TransactionManagerWithChangeSetImpl(client.transactionManager(options));
   }
 
   /**
@@ -530,7 +530,7 @@ public class DatabaseClientWithChangeSets implements DatabaseClient {
    */
   @Override
   public AsyncRunnerWithChangeSet runAsync(TransactionOption... options) {
-    return new AsyncRunnerWithChangeSetImpl(client.runAsync());
+    return new AsyncRunnerWithChangeSetImpl(client.runAsync(options));
   }
 
   /**
@@ -581,7 +581,7 @@ public class DatabaseClientWithChangeSets implements DatabaseClient {
   @Override
   public AsyncTransactionManagerWithChangeSet transactionManagerAsync(
       TransactionOption... options) {
-    return new AsyncTransactionManagerWithChangeSetImpl(client.transactionManagerAsync());
+    return new AsyncTransactionManagerWithChangeSetImpl(client.transactionManagerAsync(options));
   }
 
   @Override
@@ -616,7 +616,7 @@ public class DatabaseClientWithChangeSets implements DatabaseClient {
 
   @Override
   public long executePartitionedUpdate(Statement stmt, UpdateOption... options) {
-    return client.executePartitionedUpdate(stmt);
+    return client.executePartitionedUpdate(stmt, options);
   }
 
   @Override

--- a/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/DatabaseClientWithChangeSets.java
+++ b/google-cloud-spanner-change-watcher/src/main/java/com/google/cloud/spanner/watcher/DatabaseClientWithChangeSets.java
@@ -22,10 +22,13 @@ import com.google.api.core.ApiFutures;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.AsyncRunner;
 import com.google.cloud.spanner.AsyncTransactionManager;
+import com.google.cloud.spanner.CommitResponse;
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Mutation.Op;
+import com.google.cloud.spanner.Options.TransactionOption;
+import com.google.cloud.spanner.Options.UpdateOption;
 import com.google.cloud.spanner.ReadContext;
 import com.google.cloud.spanner.ReadOnlyTransaction;
 import com.google.cloud.spanner.SpannerException;
@@ -83,6 +86,7 @@ public class DatabaseClientWithChangeSets implements DatabaseClient {
 
     private RandomUUIDChangeSetIdGenerator() {}
 
+    @Override
     public String generateChangeSetId() {
       return UUID.randomUUID().toString();
     }
@@ -95,6 +99,7 @@ public class DatabaseClientWithChangeSets implements DatabaseClient {
       this.changeSetId = idGenerator.generateChangeSetId();
     }
 
+    @Override
     public String getChangeSetId() {
       return changeSetId;
     }
@@ -108,6 +113,7 @@ public class DatabaseClientWithChangeSets implements DatabaseClient {
       this.runner = runner;
     }
 
+    @Override
     public <T> T run(TransactionCallable<T> callable) {
       return runner.run(
           new TransactionCallable<T>() {
@@ -119,10 +125,12 @@ public class DatabaseClientWithChangeSets implements DatabaseClient {
           });
     }
 
+    @Override
     public Timestamp getCommitTimestamp() {
       return runner.getCommitTimestamp();
     }
 
+    @Override
     public TransactionRunner allowNestedTransaction() {
       return runner.allowNestedTransaction();
     }
@@ -136,34 +144,41 @@ public class DatabaseClientWithChangeSets implements DatabaseClient {
       this.manager = manager;
     }
 
+    @Override
     public TransactionContext begin() {
       TransactionContext context = manager.begin();
       context.buffer(createChangeSetMutation(changeSetId));
       return context;
     }
 
+    @Override
     public void commit() {
       manager.commit();
     }
 
+    @Override
     public void rollback() {
       manager.rollback();
     }
 
+    @Override
     public TransactionContext resetForRetry() {
       TransactionContext context = manager.resetForRetry();
       context.buffer(createChangeSetMutation(changeSetId));
       return context;
     }
 
+    @Override
     public Timestamp getCommitTimestamp() {
       return manager.getCommitTimestamp();
     }
 
+    @Override
     public TransactionState getState() {
       return manager.getState();
     }
 
+    @Override
     public void close() {
       manager.close();
     }
@@ -190,6 +205,7 @@ public class DatabaseClientWithChangeSets implements DatabaseClient {
           executor);
     }
 
+    @Override
     public ApiFuture<Timestamp> getCommitTimestamp() {
       return runner.getCommitTimestamp();
     }
@@ -203,6 +219,7 @@ public class DatabaseClientWithChangeSets implements DatabaseClient {
       this.manager = manager;
     }
 
+    @Override
     public TransactionContextFuture beginAsync() {
       TransactionContextFuture context = manager.beginAsync();
       ApiFutures.addCallback(
@@ -220,10 +237,12 @@ public class DatabaseClientWithChangeSets implements DatabaseClient {
       return context;
     }
 
+    @Override
     public ApiFuture<Void> rollbackAsync() {
       return manager.rollbackAsync();
     }
 
+    @Override
     public TransactionContextFuture resetForRetryAsync() {
       TransactionContextFuture context = manager.resetForRetryAsync();
       ApiFutures.addCallback(
@@ -241,12 +260,19 @@ public class DatabaseClientWithChangeSets implements DatabaseClient {
       return context;
     }
 
+    @Override
     public TransactionState getState() {
       return manager.getState();
     }
 
+    @Override
     public void close() {
       manager.close();
+    }
+
+    @Override
+    public ApiFuture<Void> closeAsync() {
+      return manager.closeAsync();
     }
   }
 
@@ -427,8 +453,9 @@ public class DatabaseClientWithChangeSets implements DatabaseClient {
    *     });
    * </code></pre>
    */
-  public TransactionRunnerWithChangeSet readWriteTransaction() {
-    return new TransactionRunnerWithChangeSetImpl(client.readWriteTransaction());
+  @Override
+  public TransactionRunnerWithChangeSet readWriteTransaction(TransactionOption... options) {
+    return new TransactionRunnerWithChangeSetImpl(client.readWriteTransaction(options));
   }
 
   /**
@@ -462,7 +489,8 @@ public class DatabaseClientWithChangeSets implements DatabaseClient {
    * }
    * }</pre>
    */
-  public TransactionManagerWithChangeSet transactionManager() {
+  @Override
+  public TransactionManagerWithChangeSet transactionManager(TransactionOption... options) {
     return new TransactionManagerWithChangeSetImpl(client.transactionManager());
   }
 
@@ -500,7 +528,8 @@ public class DatabaseClientWithChangeSets implements DatabaseClient {
    *         executor);
    * </code></pre>
    */
-  public AsyncRunnerWithChangeSet runAsync() {
+  @Override
+  public AsyncRunnerWithChangeSet runAsync(TransactionOption... options) {
     return new AsyncRunnerWithChangeSetImpl(client.runAsync());
   }
 
@@ -549,35 +578,56 @@ public class DatabaseClientWithChangeSets implements DatabaseClient {
    * }
    * }</pre>
    */
-  public AsyncTransactionManagerWithChangeSet transactionManagerAsync() {
+  @Override
+  public AsyncTransactionManagerWithChangeSet transactionManagerAsync(
+      TransactionOption... options) {
     return new AsyncTransactionManagerWithChangeSetImpl(client.transactionManagerAsync());
   }
 
+  @Override
   public ReadContext singleUse() {
     return client.singleUse();
   }
 
+  @Override
   public ReadContext singleUse(TimestampBound bound) {
     return client.singleUse(bound);
   }
 
+  @Override
   public ReadOnlyTransaction singleUseReadOnlyTransaction() {
     return client.singleUseReadOnlyTransaction();
   }
 
+  @Override
   public ReadOnlyTransaction singleUseReadOnlyTransaction(TimestampBound bound) {
     return client.singleUseReadOnlyTransaction(bound);
   }
 
+  @Override
   public ReadOnlyTransaction readOnlyTransaction() {
     return client.readOnlyTransaction();
   }
 
+  @Override
   public ReadOnlyTransaction readOnlyTransaction(TimestampBound bound) {
     return client.readOnlyTransaction(bound);
   }
 
-  public long executePartitionedUpdate(Statement stmt) {
+  @Override
+  public long executePartitionedUpdate(Statement stmt, UpdateOption... options) {
     return client.executePartitionedUpdate(stmt);
+  }
+
+  @Override
+  public CommitResponse writeWithOptions(Iterable<Mutation> mutations, TransactionOption... options)
+      throws SpannerException {
+    return client.writeWithOptions(mutations, options);
+  }
+
+  @Override
+  public CommitResponse writeAtLeastOnceWithOptions(
+      Iterable<Mutation> mutations, TransactionOption... options) throws SpannerException {
+    return client.writeAtLeastOnceWithOptions(mutations, options);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloudspannerecosystem</groupId>
   <artifactId>spanner-change-watcher</artifactId>
-  <version>0.3.0</version>
+  <version>0.4.0</version>
   <name>Google Cloud Spanner Change Watcher Parent</name>
   <description>Google Cloud Spanner Change Watcher and Publisher is a framework that emits events when a row has been changed in a Cloud Spanner database. These row change events can be captured and processed in-process as part of a user application, or they can be published to Google Cloud Pubsub for consumption by any other application.</description>
   <url>https://github.com/cloudspannerecosystem/spanner-change-watcher</url>
@@ -57,6 +57,7 @@
     
     <avro.version>1.9.2</avro.version>
     
+    <gax.version>1.60.1</gax.version>
     <junit.version>4.13.1</junit.version>
     <truth.version>1.0.1</truth.version>
     <mockito.version>3.3.3</mockito.version>
@@ -67,7 +68,7 @@
       <dependency>
         <groupId>com.google.cloudspannerecosystem</groupId>
         <artifactId>google-cloud-spanner-change-watcher</artifactId>
-        <version>0.3.0</version>
+        <version>0.4.0</version>
         <exclusions>
           <exclusion>
             <groupId>org.conscrypt</groupId>
@@ -78,12 +79,12 @@
       <dependency>
         <groupId>com.google.cloudspannerecosystem</groupId>
         <artifactId>google-cloud-spanner-change-publisher</artifactId>
-        <version>0.3.0</version>
+        <version>0.4.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.cloudspannerecosystem</groupId>
         <artifactId>google-cloud-spanner-change-archiver</artifactId>
-        <version>0.3.0</version>
+        <version>0.4.0</version>
       </dependency>
       
       <dependency>
@@ -91,13 +92,13 @@
         <artifactId>google-cloud-spanner-bom</artifactId>
         <type>pom</type>
         <scope>import</scope>
-        <version>2.0.2</version>
+        <version>3.3.2</version>
       </dependency>
        
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>10.1.0</version>
+        <version>16.3.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloudspannerecosystem</groupId>
   <artifactId>spanner-change-watcher</artifactId>
-  <version>0.4.0</version>
+  <version>1.0.0</version>
   <name>Google Cloud Spanner Change Watcher Parent</name>
   <description>Google Cloud Spanner Change Watcher and Publisher is a framework that emits events when a row has been changed in a Cloud Spanner database. These row change events can be captured and processed in-process as part of a user application, or they can be published to Google Cloud Pubsub for consumption by any other application.</description>
   <url>https://github.com/cloudspannerecosystem/spanner-change-watcher</url>
@@ -68,7 +68,7 @@
       <dependency>
         <groupId>com.google.cloudspannerecosystem</groupId>
         <artifactId>google-cloud-spanner-change-watcher</artifactId>
-        <version>0.4.0</version>
+        <version>1.0.0</version>
         <exclusions>
           <exclusion>
             <groupId>org.conscrypt</groupId>
@@ -79,12 +79,12 @@
       <dependency>
         <groupId>com.google.cloudspannerecosystem</groupId>
         <artifactId>google-cloud-spanner-change-publisher</artifactId>
-        <version>0.4.0</version>
+        <version>1.0.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.cloudspannerecosystem</groupId>
         <artifactId>google-cloud-spanner-change-archiver</artifactId>
-        <version>0.4.0</version>
+        <version>1.0.0</version>
       </dependency>
       
       <dependency>

--- a/samples/spanner-change-publisher-samples/pom.xml
+++ b/samples/spanner-change-publisher-samples/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.google.cloudspannerecosystem</groupId>
     <artifactId>spanner-change-watcher</artifactId>
-    <version>0.3.0</version>
+    <version>0.4.0</version>
     <relativePath>../..</relativePath>
   </parent>
   
@@ -42,14 +42,14 @@
     <dependency>
       <groupId>com.google.cloudspannerecosystem</groupId>
       <artifactId>google-cloud-spanner-change-publisher</artifactId>
-      <version>0.3.0</version>
+      <version>0.4.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.cloudspannerecosystem</groupId>
       <artifactId>google-cloud-spanner-change-watcher</artifactId>
-      <version>0.3.0</version>
+      <version>0.4.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/samples/spanner-change-publisher-samples/pom.xml
+++ b/samples/spanner-change-publisher-samples/pom.xml
@@ -5,14 +5,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloudspannerecosystem</groupId>
   <artifactId>spanner-change-publisher-samples</artifactId>
-  <version>0.3.0</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
   <name>Google Cloud Spanner Change Publisher Samples</name>
   <description>Google Cloud Spanner Data Change Publisher Samples</description>
   <parent>
     <groupId>com.google.cloudspannerecosystem</groupId>
     <artifactId>spanner-change-watcher</artifactId>
-    <version>0.4.0</version>
+    <version>1.0.0</version>
     <relativePath>../..</relativePath>
   </parent>
   
@@ -42,14 +42,14 @@
     <dependency>
       <groupId>com.google.cloudspannerecosystem</groupId>
       <artifactId>google-cloud-spanner-change-publisher</artifactId>
-      <version>0.4.0</version>
+      <version>1.0.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.cloudspannerecosystem</groupId>
       <artifactId>google-cloud-spanner-change-watcher</artifactId>
-      <version>0.4.0</version>
+      <version>1.0.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/samples/spanner-change-watcher-samples/pom.xml
+++ b/samples/spanner-change-watcher-samples/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.google.cloudspannerecosystem</groupId>
     <artifactId>spanner-change-watcher</artifactId>
-    <version>0.3.0</version>
+    <version>0.4.0</version>
     <relativePath>../..</relativePath>
   </parent>
   
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>com.google.cloudspannerecosystem</groupId>
       <artifactId>google-cloud-spanner-change-watcher</artifactId>
-      <version>0.3.0</version>
+      <version>0.4.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/samples/spanner-change-watcher-samples/pom.xml
+++ b/samples/spanner-change-watcher-samples/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.google.cloudspannerecosystem</groupId>
     <artifactId>spanner-change-watcher</artifactId>
-    <version>0.4.0</version>
+    <version>1.0.0</version>
     <relativePath>../..</relativePath>
   </parent>
   
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>com.google.cloudspannerecosystem</groupId>
       <artifactId>google-cloud-spanner-change-watcher</artifactId>
-      <version>0.4.0</version>
+      <version>1.0.0</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
* Updates Spanner client library version to 3.3.2 from 2.x.
* Bumps own major version from 0 to 1 as Spanner has a major version bump.