### PR TITLE
feat: support limit clause in poll query

### DIFF
--- a/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/AbstractMockServerTest.java
+++ b/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/AbstractMockServerTest.java
@@ -486,6 +486,8 @@ public abstract class AbstractMockServerTest {
                   "`Foo`",
                   "LastModified",
                   "LastModified"))
+          .bind("limit")
+          .to(Long.MAX_VALUE)
           .bind("prevCommitTimestamp")
           .to(Timestamp.MIN_VALUE)
           .build();
@@ -505,6 +507,8 @@ public abstract class AbstractMockServerTest {
                       60)
                   + ")"
                   + String.format(SpannerTableTailer.POLL_QUERY_ORDER_BY, "LastModified"))
+          .bind("limit")
+          .to(Long.MAX_VALUE)
           .bind("prevCommitTimestamp")
           .to(Timestamp.MIN_VALUE)
           .build();
@@ -518,6 +522,8 @@ public abstract class AbstractMockServerTest {
                       "LastModified")
                   + " AND `ShardId` IS NOT NULL"
                   + String.format(SpannerTableTailer.POLL_QUERY_ORDER_BY, "LastModified"))
+          .bind("limit")
+          .to(Long.MAX_VALUE)
           .bind("prevCommitTimestamp")
           .to(Timestamp.MIN_VALUE)
           .build();
@@ -551,6 +557,8 @@ public abstract class AbstractMockServerTest {
                   "`Bar`",
                   "LastModified",
                   "LastModified"))
+          .bind("limit")
+          .to(Long.MAX_VALUE)
           .bind("prevCommitTimestamp")
           .to(Timestamp.MIN_VALUE)
           .build();

--- a/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/SpannerDatabaseTailerTest.java
+++ b/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/SpannerDatabaseTailerTest.java
@@ -290,10 +290,7 @@ public class SpannerDatabaseTailerTest extends AbstractMockServerTest {
                 .build()));
     mockSpanner.putStatementResult(
         StatementResult.query(
-            statement.toBuilder()
-            .bind("prevCommitTimestamp")
-            .to(ts)
-            .build(),
+            statement.toBuilder().bind("prevCommitTimestamp").to(ts).build(),
             new RandomResultSetGenerator(0).generate().toBuilder().setMetadata(metadata).build()));
 
     Spanner spanner = getSpanner();

--- a/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/SpannerDatabaseTailerTest.java
+++ b/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/SpannerDatabaseTailerTest.java
@@ -273,7 +273,10 @@ public class SpannerDatabaseTailerTest extends AbstractMockServerTest {
                 "SELECT *\n"
                     + "FROM `Foo`\n"
                     + "WHERE `AlternativeCommitTS`>@prevCommitTimestamp\n"
-                    + "ORDER BY `AlternativeCommitTS`")
+                    + "ORDER BY `AlternativeCommitTS`\n"
+                    + "LIMIT @limit")
+            .bind("limit")
+            .to(Long.MAX_VALUE)
             .bind("prevCommitTimestamp")
             .to(Timestamp.MIN_VALUE)
             .build();
@@ -287,7 +290,10 @@ public class SpannerDatabaseTailerTest extends AbstractMockServerTest {
                 .build()));
     mockSpanner.putStatementResult(
         StatementResult.query(
-            statement.toBuilder().bind("prevCommitTimestamp").to(ts).build(),
+            statement.toBuilder()
+            .bind("prevCommitTimestamp")
+            .to(ts)
+            .build(),
             new RandomResultSetGenerator(0).generate().toBuilder().setMetadata(metadata).build()));
 
     Spanner spanner = getSpanner();

--- a/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/SpannerTableTailerTest.java
+++ b/google-cloud-spanner-change-watcher/src/test/java/com/google/cloud/spanner/watcher/SpannerTableTailerTest.java
@@ -339,7 +339,10 @@ public class SpannerTableTailerTest extends AbstractMockServerTest {
                 "SELECT *\n"
                     + "FROM `Foo`\n"
                     + "WHERE `AlternativeCommitTS`>@prevCommitTimestamp\n"
-                    + "ORDER BY `AlternativeCommitTS`")
+                    + "ORDER BY `AlternativeCommitTS`\n"
+                    + "LIMIT @limit")
+            .bind("limit")
+            .to(Long.MAX_VALUE)
             .bind("prevCommitTimestamp")
             .to(Timestamp.MIN_VALUE)
             .build();
@@ -389,7 +392,10 @@ public class SpannerTableTailerTest extends AbstractMockServerTest {
                 "SELECT *\n"
                     + "FROM `Foo`\n"
                     + "WHERE `AlternativeCommitTS`>@prevCommitTimestamp\n"
-                    + "ORDER BY `AlternativeCommitTS`")
+                    + "ORDER BY `AlternativeCommitTS`\n"
+                    + "LIMIT @limit")
+            .bind("limit")
+            .to(Long.MAX_VALUE)
             .bind("prevCommitTimestamp")
             .to(Timestamp.MIN_VALUE)
             .build();


### PR DESCRIPTION
Support setting a limit for a poll query. This can increase efficiency of polling of tables that receive a very high rate of writes, as each poll will be smaller and consume less resources, but will be executed more often.
