### PR TITLE
test: countdown latch after registering received message

### DIFF
--- a/google-cloud-spanner-change-publisher/src/test/java/com/google/cloud/spanner/publisher/SpannerDatabaseChangeEventPublisherTest.java
+++ b/google-cloud-spanner-change-publisher/src/test/java/com/google/cloud/spanner/publisher/SpannerDatabaseChangeEventPublisherTest.java
@@ -115,9 +115,9 @@ public class SpannerDatabaseChangeEventPublisherTest extends AbstractMockServerT
                 new MessageReceiver() {
                   @Override
                   public void receiveMessage(PubsubMessage message, AckReplyConsumer consumer) {
-                    latch.countDown();
                     receivedMessages.incrementAndGet();
                     consumer.ack();
+                    latch.countDown();
                   }
                 })
             .setChannelProvider(channelProvider)


### PR DESCRIPTION
Count down latch after registering the received message to prevent flaky test failures.

Fixes this flaky failure: https://app.circleci.com/pipelines/github/cloudspannerecosystem/spanner-change-watcher/464/workflows/25eed194-208a-4511-a4c0-8d40134b6ed3/jobs/470

