### PR TITLE
test: increase timeouts for sample tests

### DIFF
--- a/samples/spanner-change-watcher-samples/src/main/java/com/google/cloud/spanner/watcher/sample/Samples.java
+++ b/samples/spanner-change-watcher-samples/src/main/java/com/google/cloud/spanner/watcher/sample/Samples.java
@@ -697,11 +697,12 @@ public class Samples {
    *
    * <ol>
    *   <li>A table that has been updated using DML with a PENDING_COMMIT_TIMESTAMP() function call
-   *       will no longer be readable during the remainder of the transaction (see {@link
-   *       https://cloud.google.com/spanner/docs/commit-timestamp#dml})
+   *       will no longer be readable during the remainder of the transaction.
+   *       See also https://cloud.google.com/spanner/docs/commit-timestamp#dml
    *   <li>A commit timestamp column alone should not be indexed. Instead, it should only be
    *       included in an index where the first part of the index is not a monotonically increasing
-   *       value (see {@link https://cloud.google.com/spanner/docs/commit-timestamp#keys-indexes})
+   *       value.
+   *       See also https://cloud.google.com/spanner/docs/commit-timestamp#keys-indexes
    * </ol>
    *
    * An application can use a {@link SpannerTableChangeSetPoller} or {@link


### PR DESCRIPTION
Some nightly builds have failed lately due to timeouts in the sample tests. This change increases the timeout values to what should be a safe value.