### PR TITLE
docs: recommend change-streams instead of change-watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Google Cloud Spanner Change Watcher and Publisher
 
-Cloud Spanner has officially released native change streams support, which is recommended instead of this solution.
+__Cloud Spanner has officially released native change streams support, which is recommended instead of this solution.__
 
 For more information see https://cloud.google.com/spanner/docs/change-streams.
 
@@ -111,6 +111,8 @@ See [Spanner Change Archiver README file](./google-cloud-spanner-change-archiver
 for more information.
 
 ## Limitations
+* Cloud Spanner has officially released native change streams support, which is recommended instead of this solution.
+  For more information see https://cloud.google.com/spanner/docs/change-streams.
 * Spanner Change Watcher and Spanner Change Publisher by default use
   [commit timestamps](https://cloud.google.com/spanner/docs/commit-timestamp) to determine when a
   change has occurred. Tables that do not include a commit timestamp can also be monitored, but require

--- a/google-cloud-spanner-change-archiver/README.md
+++ b/google-cloud-spanner-change-archiver/README.md
@@ -1,4 +1,8 @@
 # Spanner Change Archiver
+__Cloud Spanner has officially released native change streams support, which is recommended instead of this solution.__
+
+For more information see https://cloud.google.com/spanner/docs/change-streams.
+
 Spanner Change Archiver is an example application using a Spanner Change
 Publisher to publish changes in a Google Cloud Spanner database to a Pubsub
 topic. This topic is used as a trigger for a Google Cloud Function that writes

--- a/google-cloud-spanner-change-publisher/README.md
+++ b/google-cloud-spanner-change-publisher/README.md
@@ -1,5 +1,9 @@
 # Spanner Change Publisher
 
+__Cloud Spanner has officially released native change streams support, which is recommended instead of this solution.__
+
+For more information see https://cloud.google.com/spanner/docs/change-streams.
+
 ## Introduction
 Spanner Change Publisher watches a Spanner database for changes and publishes
 these changes to Pubsub. It can monitor a single table, a set of tables, or all
@@ -234,6 +238,8 @@ subscriber.startAsync().awaitRunning();
 ```
 
 ## Limitations
+* Cloud Spanner has officially released native change streams support, which is recommended instead of this solution.
+  For more information see https://cloud.google.com/spanner/docs/change-streams.
 * Spanner Change Publisher use [commit timestamps](https://cloud.google.com/spanner/docs/commit-timestamp) to determine when a
   change has occurred. They cannot be used on tables that do not include a commit timestamp.
 * Deletes are not detected, unless these are soft deletes that only update a deleted flag in the corresponding table.

--- a/google-cloud-spanner-change-watcher/README.md
+++ b/google-cloud-spanner-change-watcher/README.md
@@ -1,5 +1,9 @@
 # Spanner Change Watcher
 
+__Cloud Spanner has officially released native change streams support, which is recommended instead of this solution.__
+
+For more information see https://cloud.google.com/spanner/docs/change-streams.
+
 ## Introduction
 Spanner Change Watcher watches Spanner databases and tables for changes and
 emits events when changes are detected. This framework can be included in an
@@ -74,6 +78,8 @@ Take a look at [Samples.java](../samples/spanner-change-watcher-samples/src/main
 for additional examples of more advanced use cases.
 
 ## Limitations
+* Cloud Spanner has officially released native change streams support, which is recommended instead of this solution.
+  For more information see https://cloud.google.com/spanner/docs/change-streams.
 * Spanner Change Watcher and Spanner Change Publisher by default use
   [commit timestamps](https://cloud.google.com/spanner/docs/commit-timestamp) to determine when a
   change has occurred. Tables that do not include a commit timestamp can also be monitored, but require


### PR DESCRIPTION
Updates all readme files to recommend change-streams over change-watcher.

@thiagotnunes