### PR TITLE
docs: add limitation for PostgreSQL databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ for more information.
 ## Limitations
 * Cloud Spanner has officially released native change streams support, which is recommended instead of this solution.
   For more information see https://cloud.google.com/spanner/docs/change-streams.
+* Spanner Change Watcher does not support PostgreSQL dialect databases.
 * Spanner Change Watcher and Spanner Change Publisher by default use
   [commit timestamps](https://cloud.google.com/spanner/docs/commit-timestamp) to determine when a
   change has occurred. Tables that do not include a commit timestamp can also be monitored, but require

--- a/google-cloud-spanner-change-publisher/README.md
+++ b/google-cloud-spanner-change-publisher/README.md
@@ -240,6 +240,7 @@ subscriber.startAsync().awaitRunning();
 ## Limitations
 * Cloud Spanner has officially released native change streams support, which is recommended instead of this solution.
   For more information see https://cloud.google.com/spanner/docs/change-streams.
+* Spanner Change Publisher does not support PostgreSQL dialect databases.
 * Spanner Change Publisher use [commit timestamps](https://cloud.google.com/spanner/docs/commit-timestamp) to determine when a
   change has occurred. They cannot be used on tables that do not include a commit timestamp.
 * Deletes are not detected, unless these are soft deletes that only update a deleted flag in the corresponding table.

--- a/google-cloud-spanner-change-watcher/README.md
+++ b/google-cloud-spanner-change-watcher/README.md
@@ -80,6 +80,7 @@ for additional examples of more advanced use cases.
 ## Limitations
 * Cloud Spanner has officially released native change streams support, which is recommended instead of this solution.
   For more information see https://cloud.google.com/spanner/docs/change-streams.
+* Spanner Change Watcher does not support PostgreSQL dialect databases.
 * Spanner Change Watcher and Spanner Change Publisher by default use
   [commit timestamps](https://cloud.google.com/spanner/docs/commit-timestamp) to determine when a
   change has occurred. Tables that do not include a commit timestamp can also be monitored, but require


### PR DESCRIPTION
Adds a limitation to the READMEs that PostgreSQL databases are not supported.