### PR TITLE
build: use a fixed test instance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,13 @@ jobs:
         steps:
           - run: 
               name: Run Integration and Stress Tests
-              command: mvn -B -Penable-integration-tests -Pstress-integration-tests -DtrimStackTrace=false -fae verify --settings 'pom.xml'
+              command: mvn -B -Penable-integration-tests -Pstress-integration-tests -DtrimStackTrace=false -Dspanner.instance=continuous-integration-test -fae verify --settings 'pom.xml'
     - unless:
         condition: << parameters.run-stress-tests >>
         steps:
             - run:
                 name: Run Integration Tests
-                command: mvn -B -Penable-integration-tests -DtrimStackTrace=false -fae verify
+                command: mvn -B -Penable-integration-tests -DtrimStackTrace=false -Dspanner.instance=continuous-integration-test -fae verify
     - save_cache:
         paths:
         - ~/.m2


### PR DESCRIPTION
Use a fixed test instance instead of trying to create and drop an instance for each test run.